### PR TITLE
Add discord link to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@ title: Ruffle
 			<ul>
 				<li><a href="{{ site.github_url }}">source</a></li>
 				<li><a href="http://ruffle-rs.s3-website-us-west-1.amazonaws.com/builds/web-demo/">demo</a>
+				<li><a href="https://discord.gg/J8hgCQN">discord</a>
 				</li>
 			</ul>
 		</main>


### PR DESCRIPTION
We had someone complain recently that they couldn't find it, so let's put it on the homepage.