### PR TITLE
Automatically updated release tables

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,15 @@
+name: Build and deploy Jekyll site to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  github-pages:
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: helaili/jekyll-action@2.0.1
+        env:
+          JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron:  '0 2 * * *'
 
 jobs:
   github-pages:

--- a/index.html
+++ b/index.html
@@ -277,10 +277,82 @@ title: Ruffle
 						as long as some code changed. Whilst we try to keep nightly builds in working order,
 						no guarantees can be made.
 					</p>
-					<p>
-						To see and download the latest nightly release, please visit our
-						<a href="https://github.com/ruffle-rs/ruffle/releases" target="_blank">releases page on github</a>.
-					</p>
+					<table class="table table-responsive-lg table-dark downloads">
+						<thead>
+							<tr>
+								<th>Version</th>
+								<th>Date</th>
+								<th>Desktop</th>
+								<th>Browser Extension</th>
+								<th>Website</th>
+							</tr>
+						</thead>
+						<tbody>
+							{% for release in prerelease limit: 3 %}
+								<tr>
+									<td>
+										{{ release.name }}
+										{% if release.prerelease %}
+											<code class="ml-1">preview</code>
+										{% endif %}
+									</td>
+									<td>{{ release.published_at | date: "%Y-%m-%d" }}</td>
+									<td>
+										<ul class="row">
+											{% assign linux = release.assets | where_exp:"item", "item.name contains '_linux'" | first %}
+											{% if linux != nil %}
+												<li><a href="{{ linux.browser_download_url}}" target="_blank">Linux</a></li>
+											{% else %}
+												<li style="text-decoration: line-through">Linux</li>
+											{% endif %}
+
+											{% assign macos = release.assets | where_exp:"item", "item.name contains '_mac'" | first %}
+											{% if macos != nil %}
+												<li><a href="{{ macos.browser_download_url}}" target="_blank">Mac OS</a></li>
+											{% else %}
+												<li style="text-decoration: line-through">Mac OS</li>
+											{% endif %}
+
+											{% assign windows = release.assets | where_exp:"item", "item.name contains '_windows'" | first %}
+											{% if windows != nil %}
+												<li><a href="{{ windows.browser_download_url}}" target="_blank">Windows</a></li>
+											{% else %}
+												<li style="text-decoration: line-through">Windows</li>
+											{% endif %}
+										</ul>
+									</td>
+									<td>
+										<ul class="row">
+
+											{% assign firefox = release.assets | where_exp:"item", "item.name contains '_firefox'" | first %}
+											{% if firefox != nil %}
+												<li><a href="{{ firefox.browser_download_url}}" target="_blank">Firefox</a></li>
+											{% else %}
+												<li style="text-decoration: line-through">Firefox</li>
+											{% endif %}
+
+											{% assign webkit = release.assets | where_exp:"item", "item.name contains '_extension'" | first %}
+											{% if webkit != nil %}
+												<li><a href="{{ webkit.browser_download_url}}" target="_blank">Chrome / Edge / Safari</a></li>
+											{% else %}
+												<li style="text-decoration: line-through">Chrome / Edge / Safari</li>
+											{% endif %}											
+										</ul>
+									</td>
+									<td>
+										<ul class="row">
+											{% assign selfhosted = release.assets | where_exp:"item", "item.name contains '_selfhosted'" | first %}
+											{% if webkit != nil %}
+												<li><a href="{{ selfhosted.browser_download_url}}" target="_blank">Self Hosted</a></li>
+											{% else %}
+												<li style="text-decoration: line-through">Self Hosted</li>
+											{% endif %}
+										</ul>
+									</td>
+								</tr>
+							{% endfor %}
+						</tbody>
+					</table>
 				</div>
 			</div>
 		</section>


### PR DESCRIPTION
This PR restores a feature from the original draft for the website with the release tables. To achieve this result, the website is now built using a jekyll github action and the result is automatically sent to a branch named `gh-pages`.

Before this PR is merged, a few things must be prepared in order to properly deploy the website:

- Create a Personnal Access Token (https://github.com/settings/tokens) with the scope `public_repo`.
- On `ruffle-rs.github.io`, create a new secret named `JEKYLL_PAT` using the personnal access token as the value.
- On the organisation, change the source of the website to use the branch `gh-pages` instead of master.

If you have any questions don't hesitate!