### PR TITLE
Copy the CNAME file to gh-pages.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,11 +18,12 @@ show_excerpts: true
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
-# exclude:
-#   - Gemfile
-#   - Gemfile.lock
-#   - node_modules
-#   - vendor/bundle/
-#   - vendor/cache/
-#   - vendor/gems/
-#   - vendor/ruby/
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - node_modules
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - docker-compose.yml


### PR DESCRIPTION
Projects that uses the gem `github-pages` are unable to copy the `CNAME` file since https://github.com/github/pages-gem/pull/535 because the file is added to the default exclude list. In order to copy the file, the default exclude list must be overridden with our own elements + 1 (Yes, the `docker-compose.yml` file is necessary. It could probably be something else but I didn't try it).

Using the jekyll configuration sections `include` and `keep_files` didn't work.