### PR TITLE
Correct minor typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@ title: Ruffle
 						<a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#javascript-api" target="_blank">
 							our documentation
 						</a>
-						for our JavasSript API and installation options.
+						for our JavaScript API and installation options.
 					</p>
 				</div>
 			</div>
@@ -510,7 +510,7 @@ title: Ruffle
 				<div class="col-base col-lg">
 					<h3>💬 Spread the word!</h3>
 					<p>
-						Is your favourite flash based site shutting down? Let them know they can add one javascript
+						Is your favourite flash based site shutting down? Let them know they can add one JavaScript
 						file
 						and keep it running!
 						Feeling nostalgic for some old flash games? Go play some on Newgrounds with ruffle


### PR DESCRIPTION
Corrects a minor typo on the usage section
Also adds capitalization to JavaScript later down the page, to make it consistent

PS
I went through the rest of the page with a spellchecker, and there were no other typos I noticed