### PR TITLE
Fix typos and grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,12 +65,12 @@ title: Ruffle
 						rely on Flash content.
 					</p>
 					<p>
-						Ruffle is entirely an open source project and maintained by volunteers. We're all passionate
-						about the preservation of internet history, and were drawn to working on this project to help
+						Ruffle is an entirely open source project maintained by volunteers. We're all passionate
+						about the preservation of internet history, and we were drawn to working on this project to help
 						preserve the many websites and plethora of content that will no longer be accessible when
 						users can no longer run the official Flash Player. If you would like to help support this
 						project, we welcome all contributions of any kind - even if it's just playing some old games
-						and seeing how well they run ;)
+						and seeing how well they run.
 					</p>
 				</div>
 			</div>
@@ -115,11 +115,11 @@ title: Ruffle
 						if you need help with that.
 					</p>
 					<p>
-						For advance usage, consult
+						For advanced usage, consult
 						<a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#javascript-api" target="_blank">
 							our documentation
 						</a>
-						for our JavasSript API and installation options.
+						for our JavaScript API and installation options.
 					</p>
 				</div>
 			</div>
@@ -127,8 +127,8 @@ title: Ruffle
 				<div class="col-base col-lg col-lg-6">
 					<h3>Installing the browser extension</h3>
 					<p>
-						If you visit websites that have Flash content but aren't using Ruffle, or may be using an older
-						version of Ruffle but you want to ensure you're using the latest and greatest, then our browser
+						If you visit websites that have Flash content but aren't using Ruffle, or you want to ensure
+						you're using the latest and greatest version of Ruffle on every website, then our browser
 						extension is the perfect thing for you!
 					</p>
 					<p>
@@ -391,7 +391,7 @@ title: Ruffle
 					<p>
 						For in-depth details, please follow our
 						<a href="https://github.com/ruffle-rs/ruffle/issues/310" target="_blank" rel="nofollow">
-							AVM 1 tracking issue on github.
+							AVM 1 tracking issue on GitHub.
 						</a>
 					</p>
 					<p>
@@ -427,7 +427,7 @@ title: Ruffle
 					<p>
 						For in-depth details, please follow our
 						<a href="https://github.com/ruffle-rs/ruffle/issues/1368" target="_blank" rel="nofollow">
-							AVM 2 tracking issue on github.
+							AVM 2 tracking issue on GitHub.
 						</a>
 					</p>
 
@@ -456,10 +456,10 @@ title: Ruffle
 				<div class="col-base col-lg">
 					<h3>♥️ How to help the project</h3>
 					<p>
-						We are entirely an open source project and do this for the sake of preserving history,
+						We are an entirely open source project and do this for the sake of preserving history,
 						and we are not a large team at that.
 						We absolutely welcome and request your help if you are willing to provide it.
-						There are 4 main ways to help this project, and we will be extremely grateful for any provided.
+						There are 4 main ways to help this project, and we will be extremely grateful for any help provided.
 					</p>
 
 				</div>
@@ -475,7 +475,7 @@ title: Ruffle
 						<a href="https://github.com/ruffle-rs/ruffle/issues" target="_blank">search for some issues to
 							tackle</a>,
 						and
-						<a href="https://discord.gg/J8hgCQN" target="_blank">join our discord</a> to ask questions!
+						<a href="https://discord.gg/J8hgCQN" target="_blank">join our Discord</a> to ask questions!
 					</p>
 				</div>
 			</div>
@@ -483,7 +483,7 @@ title: Ruffle
 				<div class="col-base col-lg">
 					<h3>🕹️ Testing content</h3>
 					<p>
-						Arguably more important than contributing code, is testing Ruffle out.
+						Arguably more important than contributing code is testing Ruffle out.
 						Go install Ruffle and try out your favourite games and animations.
 						Look for any difference from the official Flash Player, and report your findings to us.
 						If you find any bugs, changes of behaviour, performance issues or any visual differences then
@@ -498,7 +498,7 @@ title: Ruffle
 					<p>
 						If you are able and willing to, we welcome any financial support to help us fund the project
 						going
-						forwards. With your help, we can afford to spend more time dedicated to Ruffle, and pay for
+						forward. With your help, we can afford to spend more time dedicated to Ruffle, and pay for
 						expenses
 						such as build servers and hosting.
 						We accept donations and sponsorships through Open Source Collective 501(c)(6). For more
@@ -510,13 +510,13 @@ title: Ruffle
 				<div class="col-base col-lg">
 					<h3>💬 Spread the word!</h3>
 					<p>
-						Is your favourite flash based site shutting down? Let them know they can add one javascript
+						Is your favourite Flash-based site shutting down? Let them know they can add one JavaScript
 						file
 						and keep it running!
-						Feeling nostalgic for some old flash games? Go play some on Newgrounds with ruffle
+						Feeling nostalgic for some old Flash games? Go play some on Newgrounds with Ruffle
 						installed, and
 						tell your friends about it!
-						Maybe you're a streamer and looking for some silly content? There's literally decades worth,
+						Maybe you're a streamer and looking for some silly content? There's literally decades' worth,
 						now
 						unlocked and accessible once more.
 					</p>


### PR DESCRIPTION
Notable fix: "Ruffle is entirely an open source project" -> "Ruffle is an entirely open source project"