### PR TITLE
Add "demo" to header

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -25,6 +25,9 @@
           <a class="nav-link" href="/#get-involved">Get involved</a>
         </li>
         <li class="nav-item">
+          <a class="nav-link" href="https://ruffle.rs/demo" target="_blank">Demo</a>
+        </li>
+        <li class="nav-item">
           <a class="nav-link" href="https://discord.gg/J8hgCQN" target="_blank">Join Discord</a>
         </li>
       </ul>


### PR DESCRIPTION
Fixes #26
Adds a link to the demo to the header. The link is structured in exactly the same way as the other demo link.

Both these links are absolutely links, by the way. I decided not to mess around with relative links, but maybe we should use those instead?

![image](https://user-images.githubusercontent.com/34077605/105645757-b9fee980-5e69-11eb-8e9a-05877f430875.png)
