### PR TITLE
Change "Releases" link text to "Downloads"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
           <a class="nav-link" href="/#usage">Usage</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="/#releases">Releases</a>
+          <a class="nav-link" href="/#releases">Downloads</a>
         </li>
         <li class="nav-item">
           <a class="nav-link" href="/#compatibility">Compatibility</a>


### PR DESCRIPTION
Users seem to find it unintuitive to click a link labeled "Releases" to find the downloads. Changing the link label should hopefully reduce confusion.