### PR TITLE
Make splash section li's approximately even width, put padding in ul

### DIFF
--- a/assets/title.scss
+++ b/assets/title.scss
@@ -64,7 +64,7 @@ table.table-dark th {
 
 .section.splash ul {
   margin: 0;
-  padding: 0;
+  padding: 0 18vw;
   max-width: 100%;
   display: flex;
   list-style-type: none;
@@ -73,7 +73,15 @@ table.table-dark th {
 }
 
 .section.splash li {
-  padding: 10px 6vw;
+  padding: 10px 0;
+}
+
+.section.splash li:nth-child(odd) {
+  width: 33%;
+}
+
+.section.splash li:nth-child(even) {
+  width: 34%;
 }
 
 .section.content {


### PR DESCRIPTION
Fixes #25.

Edit: Worth noting, there is a side effect. Before, "Read more" ended up on two lines when the screen width was less than 410px. Now, it ends up on two lines when the screen width is less than 553px.