### PR TITLE
Update instructions for Chrome

### DIFF
--- a/assets/title.scss
+++ b/assets/title.scss
@@ -108,6 +108,10 @@ table.table-dark th {
   margin-bottom: 1rem;
 }
 
+.section.content .bold-text {
+  font-weight: bold;
+}
+
 .section.not-found {
   display: flex;
   justify-content: center;

--- a/index.html
+++ b/index.html
@@ -140,13 +140,13 @@ title: Ruffle
 					<div class="row mt-2">
 						<div class="col-base col-lg col-lg-6">
 						<h4>Chrome</h4>
+						<div class="col-base bold-text">These instructions also apply to Chromium-based browsers such as Edge, Opera and Brave.</div>
 						<ul>
 						<li>Click the "Chrome / Edge / Safari" link.</li>
-    						<li>Extract the downloaded zip file somewhere.</li>
-    						<li>Navigate to <code>chrome://extensions/</code></li>
-    						<li>Turn on Developer mode in the top right corner.</li>
-    						<li>Click Load unpacked.</li>
-    						<li>Select the folder you extracted the extension to.</li>
+						<li>Extract the downloaded zip file somewhere.</li>
+						<li>Type <code>chrome://extensions/</code> into Chrome's address bar, then press Enter.</li>
+						<li>Turn on Developer mode in the top right corner.</li>
+						<li>Drag and drop the downloaded ZIP file into the page.</li>
 						</ul>
 						<h4>Firefox</h4>
 						<ul>
@@ -165,7 +165,7 @@ title: Ruffle
 						<li>Enable <code>Develop > Allow Unsigned Extensions</code>.</li>
 						<li>Enable the extension by checking the box in <code>Safari > Preferences > Extensions</code>.</li>
 						</ul>
-						<div style="font-weight: bold;">Note: Converting the extension to be Safari compatible requires Xcode 12+ to be installed. For using the extension Safari 14+ is required</div>
+						<div class="bold-text">Note: Converting the extension to be Safari compatible requires Xcode 12+ to be installed. For using the extension Safari 14+ is required</div>
 					</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -143,7 +143,6 @@ title: Ruffle
 						<div class="col-base bold-text">These instructions also apply to Chromium-based browsers such as Edge, Opera and Brave.</div>
 						<ul>
 						<li>Click the "Chrome / Edge / Safari" link.</li>
-						<li>Extract the downloaded zip file somewhere.</li>
 						<li>Type <code>chrome://extensions/</code> into Chrome's address bar, then press Enter.</li>
 						<li>Turn on Developer mode in the top right corner.</li>
 						<li>Drag and drop the downloaded ZIP file into the page.</li>


### PR DESCRIPTION
Updated from https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#chrome.

Did not include the developer instructions.