### PR TITLE
Revert changes that kept old builds functional

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,14 +318,14 @@ title: Ruffle
 									<td>{{ release.published_at | date: "%Y-%m-%d" }}</td>
 									<td>
 										<ul class="row">
-											{% assign linux = release.assets | where_exp:"item", "item.name contains 'linux'" | first %}
+											{% assign linux = release.assets | where_exp:"item", "item.name contains '-linux'" | first %}
 											{% if linux != nil %}
 												<li><a href="{{ linux.browser_download_url}}" target="_blank">Linux</a></li>
 											{% else %}
 												<li style="text-decoration: line-through">Linux</li>
 											{% endif %}
 
-											{% assign macos = release.assets | where_exp:"item", "item.name contains 'mac'" | first %}
+											{% assign macos = release.assets | where_exp:"item", "item.name contains '-macos'" | first %}
 											{% if macos != nil %}
 												<li><a href="{{ macos.browser_download_url}}" target="_blank">Mac OS</a></li>
 											{% else %}
@@ -343,30 +343,21 @@ title: Ruffle
 											{% if windows64 != nil %}
 												<li><a href="{{ windows64.browser_download_url}}" target="_blank">Windows (64-bit)</a></li>
 											{% else %}
-											<!-- Remove once there have been 3 full days with 32-bit builds -->
-											{% assign windows = release.assets | where_exp:"item", "item.name contains 'windows.'" | first %}
-											{% if windows != nil %}
-												<li><a href="{{ windows.browser_download_url}}" target="_blank">Windows (64-bit)</a></li>
-											{% else %}
-											<!-- End Remove -->
 												<li style="text-decoration: line-through">Windows (64-bit)</li>
-											<!-- Remove once there have been 3 full days with 32-bit builds -->
-											{% endif %}
-											<!-- End Remove -->
 											{% endif %}
 										</ul>
 									</td>
 									<td>
 										<ul class="row">
 
-											{% assign firefox = release.assets | where_exp:"item", "item.name contains 'firefox'" | first %}
+											{% assign firefox = release.assets | where_exp:"item", "item.name contains '-firefox'" | first %}
 											{% if firefox != nil %}
 												<li><a href="{{ firefox.browser_download_url}}" target="_blank">Firefox</a></li>
 											{% else %}
 												<li style="text-decoration: line-through">Firefox</li>
 											{% endif %}
 
-											{% assign webkit = release.assets | where_exp:"item", "item.name contains 'extension.'" | first %}
+											{% assign webkit = release.assets | where_exp:"item", "item.name contains '-extension.'" | first %}
 											{% if webkit != nil %}
 												<li><a href="{{ webkit.browser_download_url}}" target="_blank">Chrome / Edge / Safari</a></li>
 											{% else %}
@@ -376,7 +367,7 @@ title: Ruffle
 									</td>
 									<td>
 										<ul class="row">
-											{% assign selfhosted = release.assets | where_exp:"item", "item.name contains 'selfhosted'" | first %}
+											{% assign selfhosted = release.assets | where_exp:"item", "item.name contains '-selfhosted'" | first %}
 											{% if webkit != nil %}
 												<li><a href="{{ selfhosted.browser_download_url}}" target="_blank">Self Hosted</a></li>
 											{% else %}


### PR DESCRIPTION
This is hardly a priority to merge as it causes no functional changes. However, I made it for a few reasons:

1) The removed code in the else statement will never again be true (unless release names change again), so if there were ever broken Windows 64-bit builds, it would run an extra check for no reason.
2) I had only changed the contains statements for the pre-release builds. This makes them once again match the contains statements for the full release code, and makes them more uniform with the Windows contains statements which were unchanged (still had dashes).
3) As Mike mentioned to me on Discord before my previous commits, there may be other builds with mac in the name in the future. I would not have concerned myself with that if it were not for the other two reasons, however, as the code will need to change again when new builds are added anyway. Still, if changing old release code can be avoided in favor of just adding new release code, that is better.