### PR TITLE
Show navbar properly if load is done while not at top of page

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
 
     // fade in .navbar
     $(function () {
-      $(window).scroll(function () {
+      $(window).on('scroll load', function () {
         // set distance user needs to scroll before we start fadeIn
         if ($(this).scrollTop() > window.innerHeight / 2) { //For dynamic effect use $nav.height() instead of '100'
           //$nav.fadeIn();


### PR DESCRIPTION
Reason for PR: Try going to https://ruffle.rs/ and pressing F5 on the page after scrolling down. Until the next scroll event, the navbar will be faded out. That is also sometimes (rarely) true on Google Chrome when clicking a link like https://ruffle.rs/#downloads, though that's inconsistent for reasons I'm not sure about.

![reload_ruffle_website](https://user-images.githubusercontent.com/29206584/124370406-57462100-dc45-11eb-9850-bda26c43403a.png)

Note: Not the biggest deal on desktop, but I first noticed this on mobile, where it's a far bigger annoyance. Go to https://ruffle.rs/#downloads on a phone, click the hamburger menu without scrolling, and you'll see why I opened this PR:

<img src="https://user-images.githubusercontent.com/29206584/125126577-4ecc6b00-e0c9-11eb-9fd5-3c5d85b8a061.jpg" alt="Phone menu" height="250">
