### PR TITLE
Attempt to fix the Jekyll publish

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-16.04
     steps:
       - uses: actions/checkout@v2
-      - uses: helaili/jekyll-action@2.0.1
+      - uses: helaili/jekyll-action@2.0.4
         env:
           JEKYLL_PAT: ${{ secrets.JEKYLL_PAT }}
+        with:
+          target_branch: 'gh-pages'


### PR DESCRIPTION
(I could have updated `jekyll-action` to 2.2.0, but decided to do the minimum bump necessary for a fix, to minimise risk of other breakages)
Note: I don't know if this will work, I didn't actually run this. I _hope_ it will.