### PR TITLE
Improved the 404 page!

### DIFF
--- a/404.html
+++ b/404.html
@@ -21,6 +21,18 @@ layout: default
     <h1>404: Page not found</h1>
 
     <p><strong>Unfortunatley, we can't emulate new pages into existance :/</strong></p>
-    <p>The requested page could not be found.</p>
+    <p>However, here are a few links that you might find useful!</p>
+      <ul>
+        <li><a href = "https://ruffle.rs/">Homepage</a></li>
+        <li><a href = "https://ruffle.rs/demo/">Web Demo</a></li>
+        <li><a href = "https://ruffle.rs/#downloads">Downloads</a></li>
+        <li><a href = "https://github.com/ruffle-rs">Github</a></li>
+        <li><a href = "https://discord.com/invite/ruffle">Discord server invite</a></li>
+    </ul>
+    <br>
+    <br>
+    <h3><strong>BETA FEATURE</strong></h3>
+    <p>Here is a possible suggestion for what you were looking for:</p>
+    <p id = "result">Unfortunatley we can't find anything, but this is still a wip so expect this to be updated later!</p>
   </div>
 </section>

--- a/404.html
+++ b/404.html
@@ -18,9 +18,9 @@ layout: default
 
 <section class="section not-found">
   <div class="container">
-    <h1>404</h1>
+    <h1>404: Page not found</h1>
 
-    <p><strong>Page not found :(</strong></p>
+    <p><strong>Unfortunatley, we can't emulate new pages into existance :/</strong></p>
     <p>The requested page could not be found.</p>
   </div>
 </section>

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-ruffle.rs
+jme.janbar.juniper

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+ruffle.rs

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-jme.janbar.juniper

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Ruffle
 # email: mwelsh@gmail.com
 description: >- 
   Flash Player emulator written in the Rust programming language
-baseurl: ""
+baseurl: "/ruffle-rs.github.io"
 #url: "https://ruffle.rs"
 # twitter_username: jekyllrb
 github_username:  ruffle-rs

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ baseurl: "/ruffle-rs.github.io"
 # twitter_username: jekyllrb
 github_username:  ruffle-rs
 github_url: "https://github.com/ruffle-rs/ruffle"
-repository: ruffle-rs/ruffle
+repository: JmeJuniper/ruffle-rs.github.io
 markdown: kramdown
 plugins:
   - jekyll-feed

--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Ruffle
 # email: mwelsh@gmail.com
 description: >- 
   Flash Player emulator written in the Rust programming language
-baseurl: "/ruffle-rs.github.io"
+baseurl: ""
 #url: "https://ruffle.rs"
 # twitter_username: jekyllrb
 github_username:  ruffle-rs

--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ baseurl: "/ruffle-rs.github.io"
 # twitter_username: jekyllrb
 github_username:  ruffle-rs
 github_url: "https://github.com/ruffle-rs/ruffle"
-repository: JmeJuniper/ruffle-rs.github.io
+repository: ruffle-rs/ruffle
 markdown: kramdown
 plugins:
   - jekyll-feed


### PR DESCRIPTION
I made a few changes to the 404 page. I made it a bit less bland with a simple joke (Sadly, we can't emulate new pages into existance :/) and added a list below it with links they might want. Basically how it works is it detects the path (so if you put in ruffle.rs/test/example.js, it would detect test/example.js), and see if it contains any keywords. Now this is handled by multiple if statements, and I'm sure there is a better way to handle that but anyways it detects if there is something like "home" or "download" and adds the respective links to an array which has a for loop go through it and display the links.

NOTE: This can be updated and once in a while I might do more pull requests containing more links