### PR TITLE
dev: run job on ubuntu-latest

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   github-pages:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: helaili/jekyll-action@2.2.0


### PR DESCRIPTION
By https://github.com/actions/virtual-environments/issues/3287 16 is EOL
and no longer offered.