### PR TITLE
Show unsigned Firefox builds if necessary

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,13 @@
     var $headerarrow = $('.header-down-arrow');
     //$nav.hide();
 
+    // show firefox instructions for unsigned builds if there are unsigned builds
+    if ($(".unsigned").length) {
+      $("#all_ff_instructions").show();
+      $("#signed_ff_header").html("Firefox (not unsigned)");
+      $(".col-lg-6").removeClass("col-lg-6").addClass("col-lg-4");
+      $('#signed_ff_instructions').insertAfter('#unsigned_ff_instructions');
+    }
     // fade in .navbar
     $(function () {
       $(window).on('scroll load', function () {

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,9 +11,9 @@
     // show firefox instructions for unsigned builds if there are unsigned builds
     if ($(".unsigned").length) {
       $("#all_ff_instructions").show();
-      $("#signed_ff_header").html("Firefox (not unsigned)");
+      $("#signed_ff_header").html("Firefox (standard)");
       $(".col-lg-6").removeClass("col-lg-6").addClass("col-lg-4");
-      $('#signed_ff_instructions').insertAfter('#unsigned_ff_instructions');
+      $('#signed_ff_instructions').insertBefore('#unsigned_ff_instructions');
     }
     // fade in .navbar
     $(function () {

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,13 +8,6 @@
     var $headerarrow = $('.header-down-arrow');
     //$nav.hide();
 
-    // show firefox instructions for unsigned builds if there are unsigned builds
-    if ($(".unsigned").length) {
-      $("#all_ff_instructions").show();
-      $("#signed_ff_header").html("Firefox (standard)");
-      $(".col-lg-6").removeClass("col-lg-6").addClass("col-lg-4");
-      $('#signed_ff_instructions').insertBefore('#unsigned_ff_instructions');
-    }
     // fade in .navbar
     $(function () {
       $(window).on('scroll load', function () {

--- a/_includes/release-assets.html
+++ b/_includes/release-assets.html
@@ -31,12 +31,30 @@
 </td>
 <td>
 	<ul class="row">
+		{% assign signed_firefox = include.assets | where_exp:"item", "item.name contains '-firefox.'" | first %}
+		{% assign unsigned_firefox = include.assets | where_exp:"item", "item.name contains '-firefox-unsigned'" | first %}
 
-		{% assign firefox = include.assets | where_exp:"item", "item.name contains '-firefox.'" | first %}
-		{% if firefox != nil %}
-			<li><a href="{{ firefox.browser_download_url}}" target="_blank">Firefox</a></li>
+		{% if include.latest %}
+		
+		{% if signed_firefox != nil %}
+			<li><a href="{{ signed_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
 		{% else %}
 			<li style="text-decoration: line-through">Firefox</li>
+		{% endif %}
+		{% if unsigned_firefox != nil and unsigned_firefox.name > signed_firefox.name %}
+			<li class="unsigned"><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned) - More recent</a></li>
+		{% endif %}
+		
+		{% else %}
+		
+		{% if signed_firefox != nil %}
+			<li><a href="{{ signed_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
+		{% elsif unsigned_firefox != nil %}
+			<li class="unsigned"><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned)</a></li>
+		{% else %}
+			<li style="text-decoration: line-through">Firefox</li>
+		{% endif %}
+		
 		{% endif %}
 
 		{% assign webkit = include.assets | where_exp:"item", "item.name contains '-extension.'" | first %}

--- a/_includes/release-assets.html
+++ b/_includes/release-assets.html
@@ -34,27 +34,16 @@
 		{% assign signed_firefox = include.assets | where_exp:"item", "item.name contains '-firefox.'" | first %}
 		{% assign unsigned_firefox = include.assets | where_exp:"item", "item.name contains '-firefox-unsigned'" | first %}
 
-		{% if include.latest %}
-		
 		{% if signed_firefox != nil %}
-			<li><a href="{{ signed_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
+		<li><a href="{{ signed_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
+		{% elsif include.latest != true and unsigned_firefox != nil %}
+		<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned)</a></li>
 		{% else %}
-			<li style="text-decoration: line-through">Firefox</li>
+		<li style="text-decoration: line-through">Firefox</li>
 		{% endif %}
-		{% if unsigned_firefox != nil and unsigned_firefox.name > signed_firefox.name %}
-			<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned) - More recent</a></li>
-		{% endif %}
-		
-		{% else %}
-		
-		{% if signed_firefox != nil %}
-			<li><a href="{{ signed_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
-		{% elsif unsigned_firefox != nil %}
-			<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned)</a></li>
-		{% else %}
-			<li style="text-decoration: line-through">Firefox</li>
-		{% endif %}
-		
+
+		{% if include.latest and (signed_firefox == nil or unsigned_firefox != nil and unsigned_firefox.created_at > signed_firefox.created_at) %}
+		<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned) - More recent</a></li>
 		{% endif %}
 
 		{% assign webkit = include.assets | where_exp:"item", "item.name contains '-extension.'" | first %}

--- a/_includes/release-assets.html
+++ b/_includes/release-assets.html
@@ -42,7 +42,7 @@
 			<li style="text-decoration: line-through">Firefox</li>
 		{% endif %}
 		{% if unsigned_firefox != nil and unsigned_firefox.name > signed_firefox.name %}
-			<li class="unsigned"><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned) - More recent</a></li>
+			<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned) - More recent</a></li>
 		{% endif %}
 		
 		{% else %}
@@ -50,7 +50,7 @@
 		{% if signed_firefox != nil %}
 			<li><a href="{{ signed_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
 		{% elsif unsigned_firefox != nil %}
-			<li class="unsigned"><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned)</a></li>
+			<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned)</a></li>
 		{% else %}
 			<li style="text-decoration: line-through">Firefox</li>
 		{% endif %}

--- a/assets/title.scss
+++ b/assets/title.scss
@@ -120,7 +120,7 @@ table.table-dark th {
 }
 
 .section h2 {
-  padding-top:10rem;
+  padding-top:5rem;
   margin-left:1rem;
   margin-bottom: 2rem;
   text-transform: capitalize;

--- a/index.html
+++ b/index.html
@@ -147,11 +147,26 @@ title: Ruffle
 						<li>Turn on Developer mode in the top right corner.</li>
 						<li>Drag and drop the downloaded ZIP file into the page.</li>
 						</ul>
-						<h4>Firefox</h4>
+						<div id="signed_ff_instructions">
+						<h4 id="signed_ff_header">Firefox</h4>
 						<ul>
 						<li>Click the Firefox extension download link.</li>
 						<li>The browser will prompt you to install the extension.</li>
 						</ul>
+						</div>
+					</div>
+					<div class="col-base col-lg col-lg-4" style="display: none;" id="all_ff_instructions">
+						<div id="unsigned_ff_instructions">
+						<h4>Firefox (unsigned)</h4>
+						<ul>
+						<li>Right-click the Firefox (unsigned) download link.</li>
+						<li>Click "Save Link As..."</li>
+						<li>Navigate to <code>about:debugging</code>.</li>
+						<li>Click on This Firefox.</li>
+						<li>Click Load Temporary Add-on...</li>
+						<li>Select the .xpi that you downloaded.</li>
+						</ul>
+						</div>
 					</div>
 					<div class="col-base col-lg col-lg-6">
 						<h4>Safari</h4>
@@ -223,7 +238,7 @@ title: Ruffle
 						<tbody>
 							{% assign all_files = all_releases | map: "assets" | reverse | reverse %}
 							<tr>
-								{% include release-assets.html assets=all_files %}
+								{% include release-assets.html assets=all_files latest=true %}
 							</tr>
 						</tbody>
 					</table>

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ title: Ruffle
 						<a href="#downloads">our downloads</a>, and then install it manually.
 					</p>
 					<div class="row mt-2">
-						<div class="col-base col-lg col-lg-6">
+						<div class="col-base col-lg col-lg-4">
 						<h4>Chrome</h4>
 						<div class="col-base bold-text">These instructions also apply to Chromium-based browsers such as Edge, Opera and Brave.</div>
 						<ul>
@@ -147,16 +147,13 @@ title: Ruffle
 						<li>Turn on Developer mode in the top right corner.</li>
 						<li>Drag and drop the downloaded ZIP file into the page.</li>
 						</ul>
-						<div id="signed_ff_instructions">
-						<h4 id="signed_ff_header">Firefox</h4>
+					</div>
+					<div class="col-base col-lg col-lg-4">
+						<h4>Firefox (standard)</h4>
 						<ul>
 						<li>Click the Firefox extension download link.</li>
 						<li>The browser will prompt you to install the extension.</li>
 						</ul>
-						</div>
-					</div>
-					<div class="col-base col-lg col-lg-4" style="display: none;" id="all_ff_instructions">
-						<div id="unsigned_ff_instructions">
 						<h4>Firefox (unsigned)</h4>
 						<ul>
 						<li>Right-click the Firefox (unsigned) download link.</li>
@@ -166,9 +163,8 @@ title: Ruffle
 						<li>Click Load Temporary Add-on...</li>
 						<li>Select the .xpi that you downloaded.</li>
 						</ul>
-						</div>
 					</div>
-					<div class="col-base col-lg col-lg-6">
+					<div class="col-base col-lg col-lg-4">
 						<h4>Safari</h4>
 						<ul>
 						<li>Click the "Chrome / Edge / Safari" link.</li>


### PR DESCRIPTION
~~Currently, this will show the latest available Firefox build (either signed or unsigned) in the latest available column instead of both or only the signed one. I want to fix that, but I don't want to show a strike-through for the other rows, so release-assets would need some conditional logic that we may want to avoid.~~