### PR TITLE
Remove "Date" column in "Nightly Builds" table

### DIFF
--- a/_includes/releases.html
+++ b/_includes/releases.html
@@ -2,6 +2,9 @@
 	<thead>
 		<tr>
 			<th>Version</th>
+			{% comment %}
+			With the current code, the releases sent to this table are either all prereleases or all not prereleases
+			{% endcomment %}
 			{% unless include.releases.first.prerelease %}
 			<th>Date</th>
 			{% endunless %}

--- a/_includes/releases.html
+++ b/_includes/releases.html
@@ -2,7 +2,9 @@
 	<thead>
 		<tr>
 			<th>Version</th>
+			{% unless include.releases.first.prerelease %}
 			<th>Date</th>
+			{% endunless %}
 			<th>Desktop</th>
 			<th>Browser Extension</th>
 			<th>Website</th>
@@ -17,7 +19,9 @@
 						<code class="ml-1">preview</code>
 					{% endif %}
 				</td>
+				{% unless release.prerelease %}
 				<td>{{ release.published_at | date: "%Y-%m-%d" }}</td>
+				{% endunless %}
 				{% include release-assets.html assets=release.assets %}
 			</tr>
 		{% endfor %}


### PR DESCRIPTION
Supersedes #70. In contrast to that PR, this will keep the dates in the table for any potential stable releases with actual release names. Like that PR, this will remove the redundant dates from the prerelease table and keep the code de-duplication from #53 and #64 in tact. Tested locally.

For information about the logic flow used, see https://shopify.github.io/liquid/tags/control-flow/ and https://shopify.github.io/liquid/filters/first/.

In case there is a concern that some of the releases may be prereleases while others are not, see https://github.com/ruffle-rs/ruffle-rs.github.io/pull/70#issuecomment-932990273.