### PR TITLE
Update browser instructions and remove signed firefox CI download

### DIFF
--- a/_includes/release-assets.html
+++ b/_includes/release-assets.html
@@ -31,19 +31,12 @@
 </td>
 <td>
 	<ul class="row">
-		{% assign signed_firefox = include.assets | where_exp:"item", "item.name contains '-firefox.'" | first %}
 		{% assign unsigned_firefox = include.assets | where_exp:"item", "item.name contains '-firefox-unsigned'" | first %}
 
-		{% if signed_firefox != nil %}
-		<li><a href="{{ signed_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
-		{% elsif include.latest != true and unsigned_firefox != nil %}
-		<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned)</a></li>
+		{% if unsigned_firefox != nil %}
+		<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox</a></li>
 		{% else %}
 		<li style="text-decoration: line-through">Firefox</li>
-		{% endif %}
-
-		{% if include.latest and (signed_firefox == nil or unsigned_firefox != nil and unsigned_firefox.created_at > signed_firefox.created_at) %}
-		<li><a href="{{ unsigned_firefox.browser_download_url}}" target="_blank">Firefox (unsigned) - More recent</a></li>
 		{% endif %}
 
 		{% assign webkit = include.assets | where_exp:"item", "item.name contains '-extension.'" | first %}

--- a/index.html
+++ b/index.html
@@ -133,13 +133,16 @@ title: Ruffle
 						extension is the perfect thing for you!
 					</p>
 					<p>
-						Until our first release, we currently only ship a signed browser extension for Firefox. The other extensions are unsigned.
-						To use these, first download the appropriate one for your browser from
+						The easiest way to install Ruffle on Chromium-based browsers such as Chrome, Edge, Opera, and Brave is through the 
+						<a href="https://chrome.google.com/webstore/detail/ruffle/donbcfbmhbcapadipfkeojnmajbakjdc" target="_blank" rel="nofollow">Chrome Web Store</a>.
+						The easiest way to install Ruffle on Firefox is through 
+						<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow">addons.mozilla.org</a>. We also offer unsigned 
+						nightly extensions, which you can use to test the latest new features. To use these, first download the appropriate one for your browser from 
 						<a href="#downloads">our downloads</a>, and then install it manually.
 					</p>
 					<div class="row mt-2">
-						<div class="col-base col-lg col-lg-4">
-						<h4>Chrome</h4>
+						<div class="col-base col-lg col-lg-6">
+						<h4>Chrome (nightly)</h4>
 						<div class="col-base bold-text">These instructions also apply to Chromium-based browsers such as Edge, Opera and Brave.</div>
 						<ul>
 						<li>Click the "Chrome / Edge / Safari" link.</li>
@@ -147,16 +150,9 @@ title: Ruffle
 						<li>Turn on Developer mode in the top right corner.</li>
 						<li>Drag and drop the downloaded ZIP file into the page.</li>
 						</ul>
-					</div>
-					<div class="col-base col-lg col-lg-4">
-						<h4>Firefox (standard)</h4>
+						<h4>Firefox (nightly)</h4>
 						<ul>
-						<li>Click the Firefox extension download link.</li>
-						<li>The browser will prompt you to install the extension.</li>
-						</ul>
-						<h4>Firefox (unsigned)</h4>
-						<ul>
-						<li>Right-click the Firefox (unsigned) download link.</li>
+						<li>Right-click the Firefox download link.</li>
 						<li>Click "Save Link As..."</li>
 						<li>Navigate to <code>about:debugging</code>.</li>
 						<li>Click on This Firefox.</li>
@@ -164,7 +160,7 @@ title: Ruffle
 						<li>Select the .xpi that you downloaded.</li>
 						</ul>
 					</div>
-					<div class="col-base col-lg col-lg-4">
+					<div class="col-base col-lg col-lg-6">
 						<h4>Safari</h4>
 						<ul>
 						<li>Click the "Chrome / Edge / Safari" link.</li>
@@ -222,7 +218,7 @@ title: Ruffle
 					{% assign prerelease = all_releases | where_exp:"item", "item.prerelease == true" %}
 					{% assign full_release = all_releases | where_exp:"item", "item.prerelease == false" %}
 
-					<h3>Latest Release</h3>
+					<h3>Latest Nightly Release</h3>
 					<table class="table table-responsive-lg table-dark downloads">
 						<thead>
 							<tr>

--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@ title: Ruffle
 						<tbody>
 							{% assign all_files = all_releases | map: "assets" | reverse | reverse %}
 							<tr>
-								{% include release-assets.html assets=all_files latest=true %}
+								{% include release-assets.html assets=all_files %}
 							</tr>
 						</tbody>
 					</table>


### PR DESCRIPTION
Preferably, to be merged after #74. Made the assumption that the CI signed firefox build is no longer viable, and that future signed releases will always be updates to the official extensions.