### PR TITLE
Tweak store badge image styling

### DIFF
--- a/assets/title.scss
+++ b/assets/title.scss
@@ -217,8 +217,10 @@ footer ul {
   animation: octocat-wave 560ms ease-in-out
 }
 
-img .store-badge {
-  margin: 10px;
+a.store-badge {
+  margin: 5px;
+  margin-bottom: 15px;
+  display: inline-block;
 }
 
 .meter { 

--- a/index.html
+++ b/index.html
@@ -210,12 +210,12 @@ title: Ruffle
 						Ruffle is directly available as an extension in the Chrome Web Store and on addons.mozilla.org:
 					</p>
 
-					<a href="https://chrome.google.com/webstore/detail/ruffle/donbcfbmhbcapadipfkeojnmajbakjdc" target="_blank" rel="nofollow">
-						<img src="{{ "/assets/chrome_web_store.svg" | relative_url }}" width="200" height="60" alt="Chrome Web Store" class="img-fluid store-badge">
+					<a href="https://chrome.google.com/webstore/detail/ruffle/donbcfbmhbcapadipfkeojnmajbakjdc" target="_blank" rel="nofollow" class="store-badge">
+						<img src="{{ "/assets/chrome_web_store.svg" | relative_url }}" width="200" height="60" alt="Chrome Web Store" class="img-fluid">
 					</a>
 
-					<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow">
-						<img src="{{ "/assets/get-the-addon.svg" | relative_url }}" width="172" height="60" alt="addons.mozilla.org" class="img-fluid store-badge">
+					<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow" class="store-badge">
+						<img src="{{ "/assets/get-the-addon.svg" | relative_url }}" width="172" height="60" alt="addons.mozilla.org" class="img-fluid">
 					</a>
 
 					{% assign all_releases = site.github.releases | where_exp:"item", "item.draft == false" %}


### PR DESCRIPTION
This fixes some minor issues with how the badge images look, amending #74 .
 - Removes the single underlined space between the badges.
 - Actually applies the margin to the images. (Thanks @n0samu for the CSS tip!)