### PR TITLE
Remove nightly Firefox/Chrome extension instructions to reduce confusion

### DIFF
--- a/index.html
+++ b/index.html
@@ -141,11 +141,23 @@ title: Ruffle
 						The easiest way to install Ruffle on Chromium-based browsers such as Chrome, Edge, Opera, and Brave is through the
 						<a href="https://chrome.google.com/webstore/detail/ruffle/donbcfbmhbcapadipfkeojnmajbakjdc" target="_blank" rel="nofollow">Chrome Web Store</a>.
 						The easiest way to install Ruffle on Firefox is through
-						<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow">addons.mozilla.org</a>. These update whenever new
+						<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow">addons.mozilla.org</a>.
+					</p>
+					<div>
+						<a href="https://chrome.google.com/webstore/detail/ruffle/donbcfbmhbcapadipfkeojnmajbakjdc" target="_blank" rel="nofollow" class="store-badge">
+							<img src="{{ "/assets/chrome_web_store.svg" | relative_url }}" width="200" height="60" alt="Chrome Web Store" class="img-fluid">
+						</a>
+
+						<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow" class="store-badge">
+							<img src="{{ "/assets/get-the-addon.svg" | relative_url }}" width="172" height="60" alt="addons.mozilla.org" class="img-fluid">
+						</a>
+					</div>
+					<p>
+						These update whenever new
 						builds release. We also offer unsigned nightly extensions, but most people won't need them. If you do, download the appropriate one for your
 						browser from <a href="#downloads">our downloads</a>, and then install it manually. Instructions for installation of nightly Chrome/Firefox
-						extensions are available on <a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#browser-extension" target="_blank" rel="nofollow">
-						our wiki</a>. Safari instructions are below.
+						extensions available on <a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#browser-extension" target="_blank" rel="nofollow">
+						our wiki</a>. Safari instructions below.
 					</p>
 					<div class="row mt-2">
 						<div class="col-base col-lg col-lg-12">

--- a/index.html
+++ b/index.html
@@ -138,34 +138,17 @@ title: Ruffle
 						extension is the perfect thing for you!
 					</p>
 					<p>
-						The easiest way to install Ruffle on Chromium-based browsers such as Chrome, Edge, Opera, and Brave is through the 
+						The easiest way to install Ruffle on Chromium-based browsers such as Chrome, Edge, Opera, and Brave is through the
 						<a href="https://chrome.google.com/webstore/detail/ruffle/donbcfbmhbcapadipfkeojnmajbakjdc" target="_blank" rel="nofollow">Chrome Web Store</a>.
-						The easiest way to install Ruffle on Firefox is through 
-						<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow">addons.mozilla.org</a>. We also offer unsigned 
-						nightly extensions, which you can use to test the latest new features. To use these, first download the appropriate one for your browser from 
-						<a href="#downloads">our downloads</a>, and then install it manually.
+						The easiest way to install Ruffle on Firefox is through
+						<a href="https://addons.mozilla.org/firefox/addon/ruffle_rs" target="_blank" rel="nofollow">addons.mozilla.org</a>. These update whenever new
+						builds release. We also offer unsigned nightly extensions, but most people won't need them. If you do, download the appropriate one for your
+						browser from <a href="#downloads">our downloads</a>, and then install it manually. Instructions for installation of nightly Chrome/Firefox
+						extensions are available on <a href="https://github.com/ruffle-rs/ruffle/wiki/Using-Ruffle#browser-extension" target="_blank" rel="nofollow">
+						our wiki</a>. Safari instructions are below.
 					</p>
 					<div class="row mt-2">
-						<div class="col-base col-lg col-lg-6">
-						<h4>Chrome (nightly)</h4>
-						<div class="col-base bold-text">These instructions also apply to Chromium-based browsers such as Edge, Opera and Brave.</div>
-						<ul>
-						<li>Click the "Chrome / Edge / Safari" link.</li>
-						<li>Type <code>chrome://extensions/</code> into Chrome's address bar, then press Enter.</li>
-						<li>Turn on Developer mode in the top right corner.</li>
-						<li>Drag and drop the downloaded ZIP file into the page.</li>
-						</ul>
-						<h4>Firefox (nightly)</h4>
-						<ul>
-						<li>Right-click the Firefox download link.</li>
-						<li>Click "Save Link As..."</li>
-						<li>Navigate to <code>about:debugging</code>.</li>
-						<li>Click on This Firefox.</li>
-						<li>Click Load Temporary Add-on...</li>
-						<li>Select the .xpi that you downloaded.</li>
-						</ul>
-					</div>
-					<div class="col-base col-lg col-lg-6">
+						<div class="col-base col-lg col-lg-12">
 						<h4>Safari</h4>
 						<ul>
 						<li>Click the "Chrome / Edge / Safari" link.</li>


### PR DESCRIPTION
![new_browser_instructions](https://user-images.githubusercontent.com/29206584/169678832-98c7b970-471f-4869-9cb6-0ddf3e933ca4.png)
