### PR TITLE
Update Safari extension instructions

### DIFF
--- a/_includes/release-assets.html
+++ b/_includes/release-assets.html
@@ -41,9 +41,14 @@
 
 		{% assign webkit = include.assets | where_exp:"item", "item.name contains '-extension.'" | first %}
 		{% if webkit != nil %}
-			<li><a href="{{ webkit.browser_download_url}}" target="_blank">Chrome / Edge / Safari</a></li>
+			<li><a href="{{ webkit.browser_download_url}}" target="_blank">Chrome / Edge</a></li>
 		{% else %}
-			<li style="text-decoration: line-through">Chrome / Edge / Safari</li>
+			<li style="text-decoration: line-through">Chrome / Edge</li>
+		{% endif %}
+		{% if macos != nil %}
+			<li><a href="{{ macos.browser_download_url}}" target="_blank">Safari</a></li>
+		{% else %}
+			<li style="text-decoration: line-through">Safari</li>
 		{% endif %}
 	</ul>
 </td>

--- a/index.html
+++ b/index.html
@@ -163,15 +163,14 @@ title: Ruffle
 						<div class="col-base col-lg col-lg-12">
 						<h4>Safari</h4>
 						<ul>
-						<li>Click the "Chrome / Edge / Safari" link.</li>
-						<li>Extract the downloaded zip file somewhere.</li>
-						<li>Run <code>xcrun safari-web-extension-converter path/to/unzipped_folder/</code></li>
-						<li>Click "Run on Xcode".</li>
+						<li>Click the "Safari" link.</li>
+						<li>Extract the downloaded tar.gz file somewhere.</li>
+						<li>Open the extracted file and confirm the popup dialog box.</li>
 						<li>Enable <code>Safari > Preferences > Advanced > Show Develop menu in menu bar</code>.</li>
 						<li>Enable <code>Develop > Allow Unsigned Extensions</code>.</li>
 						<li>Enable the extension by checking the box in <code>Safari > Preferences > Extensions</code>.</li>
 						</ul>
-						<div class="bold-text">Note: Converting the extension to be Safari compatible requires Xcode 12+ to be installed. For using the extension Safari 14+ is required</div>
+						<div class="bold-text">Note: Safari 14+ is required</div>
 					</div>
 					</div>
 				</div>


### PR DESCRIPTION
Note: This includes the Mac OS build in the release table twice, so that Safari remains in the browser extension column even though it is bundled with the Mac OS build.