### PR TITLE
Remove preloader from Ruffle logo animation on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@ title: Ruffle
 						autoplay: "on",
 						unmuteOverlay: "hidden",
 						backgroundColor: "#37528C",
-						contextMenu: false
+						contextMenu: false,
+						preloader: false
 					});
 				});
 			</script>


### PR DESCRIPTION
I just personally feel that it works better when it drops in as the page loads without a preloader as it did before the preloader was added.