### PR TITLE
ci: Upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -11,7 +11,7 @@ jobs:
   github-pages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: helaili/jekyll-action@2.2.0
         with:
           token: ${{ secrets.JEKYLL_PAT }}


### PR DESCRIPTION
Avoid using deprecated Node 12