### PR TITLE
AVM1 and AVM2 copy update

### DIFF
--- a/index.html
+++ b/index.html
@@ -338,9 +338,9 @@ title: Ruffle
 					</p>
 
 					<p>
-					<h5>ActionScript 3 API <code>50%</code></h5>
-					<div class="meter" title="50%">
-						<span style="width:50%;"><span class="progress"></span></span>
+					<h5>ActionScript 3 API <code>52%</code></h5>
+					<div class="meter" title="52%">
+						<span style="width:52%;"><span class="progress"></span></span>
 					</div>
 					</p>
 				</div>

--- a/index.html
+++ b/index.html
@@ -311,10 +311,10 @@ title: Ruffle
 					</p>
 
 					<p>
-						Ruffle is still working on the foundational support for AVM 2, and does not yet
-						support any content that requires it. A warning will be placed in the log when
-						you attempt to play AVM 2 content, for this reason. We do plan on supporting this
-						soon!
+						Ruffle now has support for AVM 2, but enough of the API is still missing that we aren't yet
+						confident enough to claim that most games will work.
+						A warning will be presented to you when you attempt to play AVM 2 content, for this reason.
+						We hope that this will be temporary, as AVM2 support is currently increasing at a very fast pace.
 					</p>
 
 					<p>

--- a/index.html
+++ b/index.html
@@ -288,9 +288,9 @@ title: Ruffle
 						</a>
 					</p>
 					<p>
-					<h5>ActionScript 1 &amp; 2 Language <code>90%</code></h5>
-					<div class="meter" title="90%">
-						<span style="width:90%;"><span class="progress"></span></span>
+					<h5>ActionScript 1 &amp; 2 Language <code>95%</code></h5>
+					<div class="meter" title="95%">
+						<span style="width:95%;"><span class="progress"></span></span>
 					</div>
 					</p>
 

--- a/index.html
+++ b/index.html
@@ -282,6 +282,12 @@ title: Ruffle
 					</p>
 
 					<p>
+						We believe that most AVM 1 content will work, but we are aware of some graphical inaccuracies
+						and smaller bugs here and there. Please feel free to report any issues you find that are not
+						present in the original Flash Player!
+					</p>
+
+					<p>
 						For in-depth details, please follow our
 						<a href="https://github.com/ruffle-rs/ruffle/issues/310" target="_blank" rel="nofollow">
 							AVM 1 tracking issue on GitHub.


### PR DESCRIPTION
Justification for AVM1 language to 95% is that String-paths was the last big known issue, there's some bugs but otherwise we're mostly there for the language itself.

