### PR TITLE
Fix deprecation warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@ title: Ruffle
 						unmuteOverlay: "hidden",
 						backgroundColor: "#37528C",
 						contextMenu: false,
-						preloader: false
+						splashScreen: false
 					});
 				});
 			</script>


### PR DESCRIPTION
The preloader option was replaced with splashScreen in https://github.com/ruffle-rs/ruffle/pull/9802.