### PR TITLE
Get favicon assets from root path

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -9,8 +9,8 @@
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
   <link rel="stylesheet" href="{{ "/assets/title.css" | relative_url }}">
   <link href="https://fonts.googleapis.com/css?family=Exo+2&display=swap" rel="stylesheet">
-  <link rel="icon" href="assets/favicon-32.png" sizes="32x32">
-  <link rel="icon" href="assets/favicon-64.png" sizes="64x64">
-  <link rel="icon" href="assets/favicon-180.png" sizes="180x180">
+  <link rel="icon" href="/assets/favicon-32.png" sizes="32x32">
+  <link rel="icon" href="/assets/favicon-64.png" sizes="64x64">
+  <link rel="icon" href="/assets/favicon-180.png" sizes="180x180">
   {%- feed_meta -%}
 </head>


### PR DESCRIPTION
Fixes favicon not appearing on https://ruffle.rs/blog/