### PR TITLE
Fix site metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,9 @@ description: >-
   Ruffle is a Flash Player emulator written in Rust. Ruffle targets both desktop and the web using WebAssembly.
 image: "/assets/logo.svg"
 baseurl: ""
-#url: "https://ruffle.rs"
+url: "https://ruffle.rs"
 # twitter_username: jekyllrb
+github: [metadata]
 github_username: ruffle-rs
 github_url: "https://github.com/ruffle-rs/ruffle"
 repository: ruffle-rs/ruffle


### PR DESCRIPTION
- The URL field was commented out in 3863d854f87572c6846159605c8c4fbb792881a8 (all the way back in 2020!) likely by accident.
- The GitHub Metadata plugin has been failing to fetch metadata for the site. See the [latest Actions run](https://github.com/ruffle-rs/ruffle-rs.github.io/actions/runs/4738823734/jobs/8413071163#step:4:265) for example:
`GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.`
According to [this highly upvoted comment](https://github.com/github/pages-gem/issues/399#issuecomment-301827749), adding a `github: [metadata]` line to the config should fix this problem.

The goal of both of these changes is to hopefully fix the website's canonical URL being set to github.com, as seen in the page source:
`<link rel="canonical" href="https://github.com/blog/" />`
This also seems to be the cause of #128. But at the very least, these changes shouldn't hurt!