### PR TITLE
Revert part of #145

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,6 @@ image: "/assets/logo.svg"
 baseurl: ""
 url: "https://ruffle.rs"
 # twitter_username: jekyllrb
-github: [metadata]
 github_username: ruffle-rs
 github_url: "https://github.com/ruffle-rs/ruffle"
 repository: ruffle-rs/ruffle


### PR DESCRIPTION
Fixes the releases table no longer being populated (https://github.com/ruffle-rs/ruffle-rs.github.io/pull/145#issuecomment-1520882369), sorry! Turns out following the crowd wasn't such a good plan 😉 