### PR TITLE
Update AVM2 API report

### DIFF
--- a/assets/report.json
+++ b/assets/report.json
@@ -1,8 +1,8 @@
 {
   "summary": {
     "max_points": 4560,
-    "impl_points": 3379,
-    "stub_penalty": 287
+    "impl_points": 3394,
+    "stub_penalty": 289
   },
   "classes": {
     "flash.events.MouseEvent": {
@@ -360,7 +360,7 @@
       "summary": {
         "max_points": 41,
         "impl_points": 22,
-        "stub_penalty": 12
+        "stub_penalty": 10
       },
       "missing": [
         "getAtomWordBoundaryOnLeft()",
@@ -388,8 +388,6 @@
         "hasGraphicElement",
         "ascent",
         "textBlockBeginIndex",
-        "textHeight",
-        "textWidth",
         "unjustifiedTextWidth",
         "getAtomBounds()",
         "validity",
@@ -658,14 +656,11 @@
     "flash.text.engine.GroupElement": {
       "summary": {
         "max_points": 11,
-        "impl_points": 4,
+        "impl_points": 7,
         "stub_penalty": 0
       },
       "missing": [
-        "getElementIndex()",
-        "getElementAt()",
         "ungroupElements()",
-        "splitTextElement()",
         "mergeTextElements()",
         "getElementAtCharIndex()",
         "groupElements()"
@@ -1526,16 +1521,16 @@
     "flash.ui.ContextMenu": {
       "summary": {
         "max_points": 9,
-        "impl_points": 5,
-        "stub_penalty": 0
+        "impl_points": 7,
+        "stub_penalty": 1
       },
       "missing": [
         "link",
-        "clone()",
-        "clipboardMenu",
-        "clipboardItems"
+        "clone()"
       ],
-      "stubbed": []
+      "stubbed": [
+        "static isSupported"
+      ]
     },
     "flash.globalization.LastOperationStatus": {
       "summary": {
@@ -1707,12 +1702,10 @@
     "flash.accessibility.AccessibilityImplementation": {
       "summary": {
         "max_points": 15,
-        "impl_points": 14,
+        "impl_points": 15,
         "stub_penalty": 0
       },
-      "missing": [
-        "accDoDefaultAction()"
-      ],
+      "missing": [],
       "stubbed": []
     },
     "flash.display3D.Context3DBlendFactor": {
@@ -2081,7 +2074,7 @@
       "summary": {
         "max_points": 25,
         "impl_points": 24,
-        "stub_penalty": 5
+        "stub_penalty": 6
       },
       "missing": [
         "lineShaderStyle()"
@@ -2091,6 +2084,7 @@
         "drawPath()",
         "drawRoundRectComplex()",
         "drawTriangles()",
+        "drawGraphicsData()",
         "readGraphicsData()"
       ]
     },
@@ -3855,17 +3849,10 @@
     "flash.ui.ContextMenuClipboardItems": {
       "summary": {
         "max_points": 7,
-        "impl_points": 0,
+        "impl_points": 7,
         "stub_penalty": 0
       },
-      "missing": [
-        "clear",
-        "copy",
-        "selectAll",
-        "cut",
-        "paste",
-        "clone()"
-      ],
+      "missing": [],
       "stubbed": []
     },
     "flash.display.StageAlign": {
@@ -4108,16 +4095,17 @@
     "flash.text.engine.FontDescription": {
       "summary": {
         "max_points": 11,
-        "impl_points": 7,
-        "stub_penalty": 0
+        "impl_points": 8,
+        "stub_penalty": 1
       },
       "missing": [
         "locked",
         "clone()",
-        "static isDeviceFontCompatible()",
-        "static isFontCompatible()"
+        "static isDeviceFontCompatible()"
       ],
-      "stubbed": []
+      "stubbed": [
+        "static isFontCompatible()"
+      ]
     },
     "flash.text.StyleSheet": {
       "summary": {
@@ -4952,11 +4940,10 @@
     "flash.system.Security": {
       "summary": {
         "max_points": 14,
-        "impl_points": 11,
+        "impl_points": 12,
         "stub_penalty": 4
       },
       "missing": [
-        "static pageDomain",
         "static exactSettings",
         "static disableAVM1Loading"
       ],
@@ -4991,14 +4978,16 @@
       "summary": {
         "max_points": 43,
         "impl_points": 40,
-        "stub_penalty": 0
+        "stub_penalty": 1
       },
       "missing": [
         "atomicCompareAndSwapLength()",
         "atomicCompareAndSwapIntAt()",
         "shareable"
       ],
-      "stubbed": []
+      "stubbed": [
+        "writeObject()"
+      ]
     },
     "flash.text.TextDisplayMode": {
       "summary": {


### PR DESCRIPTION
The overall rounded percentages remain the same.

Maximum points is still 4560.
 - implemented: 3379 -> 3394 (+15)
   - 74.10% -> 74.44% (+0.34)
 - stub penalty: 287 -> 289 (+2)
 - done: 3092 -> 3105 (+13)
   - 67.81% -> 68.09% (+0.28) 
