### PR TITLE
Fall back to unauthenticated access when GitHub PAT is unavailable

### DIFF
--- a/src/app/downloads/github.tsx
+++ b/src/app/downloads/github.tsx
@@ -1,4 +1,5 @@
 import { createTokenAuth } from "@octokit/auth-token";
+import { createUnauthenticatedAuth } from "@octokit/auth-unauthenticated";
 import {
   DownloadKey,
   FilenamePatterns,
@@ -14,7 +15,7 @@ function createGithubAuth() {
   if (process.env.GITHUB_TOKEN) {
     return createTokenAuth(process.env.GITHUB_TOKEN);
   } else {
-    return null;
+    return createUnauthenticatedAuth({reason: "Please provide a GitHub Personal Access Token via the GITHUB_TOKEN environment variable."});
   }
 }
 


### PR DESCRIPTION
Fixes error when building the site without GITHUB_TOKEN set