### PR TITLE
Make nightlies.tsx compatible with TypeScript 5.4

### DIFF
--- a/src/app/downloads/nightlies.tsx
+++ b/src/app/downloads/nightlies.tsx
@@ -18,9 +18,9 @@ import Link from "next/link";
 import classes from "./nightlies.module.css";
 import {
   desktopLinks,
-  DownloadLink,
+  type DownloadLink,
   extensionLinks,
-  GithubRelease,
+  type GithubRelease,
   githubReleasesUrl,
   webLinks,
 } from "@/app/downloads/config";


### PR DESCRIPTION
By marking the type imports from "@/app/downloads/config" explicitly as such, conforming to the new shadowing rules.

This should fix CI for https://github.com/ruffle-rs/ruffle-rs.github.io/pull/265.
Thanks to @danielhjacobs for the research: https://github.com/ruffle-rs/ruffle-rs.github.io/pull/259#issuecomment-2003883539
See: https://devblogs.microsoft.com/typescript/announcing-typescript-5-4/#errors-when-type-only-imports-conflict-with-local-values