### PR TITLE
Bump @tabler/icons-react from 2.46.0 to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@mantine/core": "7.7.1",
         "@mantine/hooks": "7.7.1",
         "@next/bundle-analyzer": "^14.1.4",
-        "@tabler/icons-react": "^2.46.0",
+        "@tabler/icons-react": "^3.1.0",
         "next": "14.1.4",
         "node-html-parser": "^6.1.13",
         "react": "^18",
@@ -962,28 +962,27 @@
       }
     },
     "node_modules/@tabler/icons": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-2.46.0.tgz",
-      "integrity": "sha512-Q5G8Pj5IO+Uhc6pszpu5/hGYY018JwEzzvmuqr+gKJtfIvAHA3umpwUilMRLEy89p+WCP+YsDhicMhfBCCv1qA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons/-/icons-3.1.0.tgz",
+      "integrity": "sha512-CpZGyS1IVJKFcv88yZ2sYZIpWWhQ6oy76BQKQ5SF0fGgOqgyqKdBGG/YGyyMW632on37MX7VqQIMTzN/uQqmFg==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/codecalm"
       }
     },
     "node_modules/@tabler/icons-react": {
-      "version": "2.46.0",
-      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-2.46.0.tgz",
-      "integrity": "sha512-X8MRxuslIOFqMjAo+GvUZDpjlOwNYNJTuOsHXf/NBvVI6ygqUf0FUNsDLLA5fQ6k6KtRwxMlgGB+eR8ZG1UP0g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@tabler/icons-react/-/icons-react-3.1.0.tgz",
+      "integrity": "sha512-k/WTlax2vbj/LpxvaJ+BmaLAAhVUgyLj4Ftgaczz66tUSNzqrAZXCFdOU7cRMYPNVBqyqE2IdQd2rzzhDEJvkw==",
       "dependencies": {
-        "@tabler/icons": "2.46.0",
-        "prop-types": "^15.7.2"
+        "@tabler/icons": "3.1.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/codecalm"
       },
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": ">= 16"
       }
     },
     "node_modules/@types/aws-lambda": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@mantine/core": "7.7.1",
     "@mantine/hooks": "7.7.1",
     "@next/bundle-analyzer": "^14.1.4",
-    "@tabler/icons-react": "^2.46.0",
+    "@tabler/icons-react": "^3.1.0",
     "next": "14.1.4",
     "node-html-parser": "^6.1.13",
     "react": "^18",

--- a/src/app/downloads/config.tsx
+++ b/src/app/downloads/config.tsx
@@ -1,12 +1,12 @@
 import {
+  Icon,
   IconBrandApple,
   IconBrandChrome,
   IconBrandEdge,
   IconBrandFirefox,
   IconBrandJavascript,
   IconBrandSafari,
-  IconBrandWindows,
-  TablerIconsProps,
+  IconBrandWindows
 } from "@tabler/icons-react";
 import React from "react";
 import { IconBrandLinux } from "@/components/icons";
@@ -87,7 +87,7 @@ export interface DownloadLink {
   /**
    * Icon to represent this link
    */
-  icon: (props: TablerIconsProps) => React.JSX.Element;
+  icon: React.ExoticComponent<React.RefAttributes<Icon>>;
 
   /**
    * Whether or not to recommend this link to the given device

--- a/src/app/installers.tsx
+++ b/src/app/installers.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import {
+  Icon,
   IconBrandJavascript,
-  IconList,
-  TablerIconsProps,
+  IconList
 } from "@tabler/icons-react";
 import React from "react";
 import { useDeviceSelectors } from "react-device-detect";
@@ -13,7 +13,7 @@ import Link from "next/link";
 import { allLinks, CurrentDevice, GithubRelease } from "@/app/downloads/config";
 
 interface RecommendedDownload {
-  icon: (props: TablerIconsProps) => React.JSX.Element;
+  icon: React.ExoticComponent<React.RefAttributes<Icon>>;
   name: string;
   url: string;
   className?: string;

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -3,6 +3,7 @@ import { createReactComponent } from "@tabler/icons-react";
 // Source: https://www.svgrepo.com/svg/340565/linux
 // Apache license
 export const IconBrandLinux = createReactComponent(
+  "outline",
   "icon-brand-linux",
   "IconBrandLinux",
   [


### PR DESCRIPTION
Supersedes https://github.com/ruffle-rs/ruffle-rs.github.io/pull/260, with manual fixes.

NOTE: I have absolutely no idea what I'm doing here, I simply kept slapping the code until the tools stopped spewing out errors.

Again thanks to @danielhjacobs: https://github.com/ruffle-rs/ruffle-rs.github.io/pull/260#issuecomment-2003876387
Referencing: https://github.com/tabler/tabler-icons/issues/1035