### PR TITLE
Change Twitter logo to X

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -2,7 +2,7 @@ import { Container, Group, ActionIcon, rem, Text } from "@mantine/core";
 import Link from "next/link";
 
 import {
-  IconBrandTwitter,
+  IconBrandX,
   IconBrandInstagram,
   IconBrandGithub,
   IconBrandTiktok,
@@ -19,9 +19,9 @@ const allSocials = [
     title: "GitHub",
   },
   {
-    type: IconBrandTwitter,
+    type: IconBrandX,
     url: "https://twitter.com/ruffle_rs",
-    title: "Twitter",
+    title: "X",
   },
   {
     type: IconBrandTiktok,


### PR DESCRIPTION
I don't like the new name (see the branch name), but it seems it's here to stay. I'd change the URL too, but x.com is still a 302 to twitter.com, so that seems pointless (side note: If it's X now, why is that not the other way around? Just Elon's incompetence? I wouldn't be surprised.)