### PR TITLE
Change button text once clicked

### DIFF
--- a/src/app/compatibility/avm2/class_box.tsx
+++ b/src/app/compatibility/avm2/class_box.tsx
@@ -54,7 +54,7 @@ export function ClassBox(props: ClassStatus) {
             className={classes.showMemberButton}
             onClick={toggle}
           >
-            Show Missing Members
+            {opened ? "Hide" : "Show"} Missing Members
           </Button>
           <List hidden={!opened}>
             {props.items.map((item, i) => (


### PR DESCRIPTION
Bit of a nitpick, but currently the buttons on the compatibility/avm2 page continue to say "Show Missing Members" even once the missing members are shown. I think updating the text once clicked would improve clarity.

Interested to hear thoughts/feedback!

Before:
<img width="1175" alt="Before" src="https://github.com/ruffle-rs/ruffle-rs.github.io/assets/61473790/ce4befc6-f4fe-4f59-b435-4b511bcbe5fd">


After:
<img width="1175" alt="After" src="https://github.com/ruffle-rs/ruffle-rs.github.io/assets/61473790/75899fc2-32bb-4500-a109-b24e5e6f405b">
