### PR TITLE
Only show implementation 100% when everything is implemented (fix #290)

### DIFF
--- a/src/app/compatibility/avm2/class_box.tsx
+++ b/src/app/compatibility/avm2/class_box.tsx
@@ -15,18 +15,19 @@ import React from "react";
 import {
   ClassStatus,
   ProgressIcon,
+  displayedPercentage,
 } from "@/app/compatibility/avm2/report_utils";
 
 export function ClassBox(props: ClassStatus) {
   const [opened, { toggle }] = useDisclosure(false);
-  const pctDone = Math.ceil(
-    ((props.summary.impl_points - props.summary.stub_penalty) /
-      props.summary.max_points) *
-      100,
+  const pctDone = displayedPercentage(
+    props.summary.impl_points - props.summary.stub_penalty,
+    props.summary.max_points,
   );
-  const pctStub = Math.ceil(
-    (props.summary.stub_penalty / props.summary.max_points) * 100,
-  );
+  const pctStub =
+    props.summary.impl_points === props.summary.max_points
+      ? 100 - pctDone
+      : displayedPercentage(props.summary.stub_penalty, props.summary.max_points);
   return (
     <Card bg="var(--ruffle-blue-9)" className={classes.class}>
       <Title order={4}>{props.name || "(Package level)"}</Title>

--- a/src/app/compatibility/avm2/report_utils.tsx
+++ b/src/app/compatibility/avm2/report_utils.tsx
@@ -143,3 +143,7 @@ export async function getReportByNamespace(): Promise<{ [name: string]: Namespac
   }
   return byNamespace;
 }
+
+export function displayedPercentage(value: number, max: number): number {
+    return value === 0 ? value : Math.max(1, Math.floor(value / max * 100));
+}


### PR DESCRIPTION
The logic is somewhat complex for a few reasons:

- Without the `Math.floor`, if all but one item was implemented in a class with over 100 items, it would show as 100% implemented, which could be misleading.
- Without the `Math.max`, if just one item was implemented in a class with over 100 items, it would show as 0% implemented, which could be misleading.
- Due to the previous two pieces of logic, without the ternary operator, if no items were implemented, it would show as 1% implemented.
- If both the percent stubbed and percent done are decimal numbers which, due to the rest of the logic, round down, the total of stubbed and done percentages could add up to less than 100% even if all the items are either stubbed or done.