### PR TITLE
Make dependabot increase version requirements for npm dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
+    versioning-strategy: increase
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
Same as https://github.com/ruffle-rs/ruffle/pull/17025

We're not even a library, it's just a wrong default here