### PR TITLE
Fix headings in posts

### DIFF
--- a/blog_posts/2023-03-12-progress-report.markdown
+++ b/blog_posts/2023-03-12-progress-report.markdown
@@ -8,7 +8,7 @@ Get ready for the biggest Ruffle announcement yet! And the first one on the blog
 
 ---
 
-### Huge improvements to Ruffle's AVM1 engine accuracy!
+## Huge improvements to Ruffle's AVM1 engine accuracy!
 Thanks to a massive code refactor by [@CUB3D](https://github.com/CUB3D/), dozens upon dozens of ActionScript 2 games have been fixed! Here are just a few of them:
 - [Chibi Knight](https://www.newgrounds.com/portal/view/526470)
 - [Xeno Tactic 2](https://www.newgrounds.com/portal/view/438241/format/flash?emulate=flash)
@@ -20,7 +20,7 @@ Thanks to a massive code refactor by [@CUB3D](https://github.com/CUB3D/), dozens
 - [The Powerpuff Girls: Attack of the Puppybots](https://flasharch.com/en/archive/play/b93354279e9788b849f83ef78f52cbbb)
 - [Extreme Pamplona](https://flasharch.com/en/archive/play/e36aac73914ec8672218317e000615d7)
 
-### Incredible progress in AVM2 (ActionScript 3) support!
+## Incredible progress in AVM2 (ActionScript 3) support!
 - Our website now has [a page listing exactly what ActionScript 3 APIs we have implemented](https://ruffle.rs/compatibility/avm2), making it easy to follow our progress. It will be frequently updated!
 - XML support is rapidly improving! ActionScript 3 games tend to use a wide variety of XML methods. As Ruffle gains support for these methods, games are springing to life!
 - Several problems that caused unresponsive buttons and menus have been fixed. Unclickable buttons in ActionScript 3 games are (mostly) a thing of the past!
@@ -49,7 +49,7 @@ Here are just a few more of the many ActionScript 3 games that are playable toda
 - [Fracuum](https://www.newgrounds.com/portal/view/594354)
 - [Dino Run: Marathon of Doom](https://www.newgrounds.com/portal/view/566176)
 
-### Last but not least, support for **mobile devices** is improving in a big way!
+## Last but not least, support for **mobile devices** is improving in a big way!
 - **Text input boxes** are finally supported on mobile devices! Tapping on a text box within Flash content now brings up the soft keyboard, so you can type into it without using a bluetooth keyboard or other workarounds.
 - The **context menu** finally works on iOS! It is activated by a long-press on the screen. To stop this behavior if needed, simply tap the "Hide this menu" option.
 

--- a/blog_posts/2023-04-23-mozilla-extension-postmortem.markdown
+++ b/blog_posts/2023-04-23-mozilla-extension-postmortem.markdown
@@ -7,14 +7,14 @@ icon: /undraw/undraw_feeling_blue_-4-b7q.svg
 
 On December 11th, 2022, our extension submissions to Firefox's extension repository, addons.mozilla.org (abbreviated as A.M.O), got stuck in review. This was shortly followed up with a far scarier notice a few days later on the 14th:
 
->Ruffle will be disabled on addons.mozilla.org  
+>Ruffle will be disabled on addons.mozilla.org
 >Due to issues discovered during the review process, one or more versions of your add-on Ruffle will be disabled on addons.mozilla.org in 14 day(s).
 
 What followed was a list of every prior submitted version of Ruffle, and a statement requesting corresponding source code. Following this, Ruffle would be unavailable for Firefox users for two months, and we spent an additional month and a half improving our CI processes to support source code review requirements for Mozilla. This is now behind us, but it is important to know why it happened.
 
 ---
 
-# The initial response
+## The initial response
 
 Our first attempt to satisfy the requirement was very naive: Mike uploads the source repository for the latest submitted version of Ruffle, version 0.1.0.685. He also includes build instructions. What followed was a game of ping-pong between Ruffle's maintainers and Mozilla's extension review team. The first reviewer skipped the `cd web` step and got an error. The second reviewer was able to correctly launch the build system, but hadn't installed a JVM. Our ActionScript 3 support requires Java, as we wrote significant portions of our AS3 builtins in ActionScript itself, which needs to be compiled by a Java binary. However, we'd failed to mention that in our build system documentation. [Oops.](https://github.com/ruffle-rs/ruffle/pull/8959)
 
@@ -22,7 +22,7 @@ At this point, Ruffle has already been removed from addons.mozilla.org, and [peo
 
 I continued pressing on with reviewer ping-pong on Mike's behalf. 0.1.0.685 was already rejected at this point, which meant that I had to submit 0.1.0.712, along with corrected build instructions. This time, the reviewer failed to install rustc instead of the JVM. Since the Dockerfile was part of 0.1.0.712, I suggested using that. The reviewer correctly built Ruffle with the Dockerfile, but the submission was rejected anyway because the compiled source code did not match the XPI we submitted.
 
-# Diffing intensifies
+## Diffing intensifies
 
 Mozilla sent over the version of the extension that they built. My first instinct was to diff all the files in both XPIs. This turns up three major categories of differences:
 
@@ -38,7 +38,7 @@ The WASM files would be more complicated. When building my laptop running Ubuntu
 
 It turned out that this difference was a fluke. Another test build done on February 2nd was identical across multiple runs. I submitted 0.1.0.742 the next day.
 
-# Reproducible means reproducible!
+## Reproducible means reproducible!
 
 Mozilla took more than a week to review this submission. The first time they looked for the XPI in the wrong place. The second time they caught actually obfuscated code in our extension script:
 
@@ -55,7 +55,7 @@ Furthermore, we don't actually have the ability to automate extension source cod
 
 0.1.0.760 is approved on February 23rd, marking Ruffle's return to addons.mozilla.org.
 
-# CI
+## CI
 
 While users can now use Ruffle again, we still need our fully automated upload pipeline. Having a maintainer fiddle with our Secrets configuration and upload two files to our addons.mozilla.org account every time we want to release is annoying and error-prone.
 
@@ -69,7 +69,7 @@ After I submitted 0.1.0.760 a month ago, I suggested a weekly release cycle for 
 
 The next weekly, 0.1.0.813, uploads automatically. The process was so smooth I literally forgot to check if it succeeded - I only noticed after seeing the approval the next Thursday. Firefox is fixed.
 
-# Context
+## Context
 
 It's tempting to read into this and get angry at Mozilla, but we also have to look at this from their perspective. Extension review is necessary to keep extensions from turning into data theft and ad-jacking operations, and average users should only be running properly reviewed extensions. We also made several mistakes during our response process that delayed our return to addons.mozilla.org. And the process resulted in genuine problems with our code being found and fixed.
 

--- a/blog_posts/2023-05-29-progress-report.markdown
+++ b/blog_posts/2023-05-29-progress-report.markdown
@@ -8,7 +8,7 @@ We have some exciting Ruffle developments to share today!
 
 ---
 
-### Big improvements in ActionScript 3!
+## Big improvements in ActionScript 3!
 
 More fan-favorite games are finally playable again!
 - [*Bloons Tower Defense 4*](https://www.kongregate.com/games/Ninjakiwi/bloons-tower-defense-4)
@@ -38,32 +38,32 @@ XML support is progressing nicely! Thanks to the great work of [@evilpie](https:
 
 Note: Because Stage3D is graphically intensive, only the Ruffle desktop app can currently run these games well.
 
-### ActionScript 2 support is improving too!
+## ActionScript 2 support is improving too!
 [@Toad06](https://github.com/Toad06/) has implemented some additional XML methods, making *Mission in Snowdriftland* playable in Ruffle! You can check it out on the [Flashpoint testing site](https://ooooooooo.ooo/static/?7d01dea2-d54f-f04a-bd84-49477152fabb) (forgive the goofy URL).
 
 <img src="/2023-05-progress-report/MissionInSnowdriftland.png" style="max-height: 350px">
 
-### The Ruffle desktop app finally has a user inteface!
+## The Ruffle desktop app finally has a user inteface!
 Thanks to the efforts of [@mike](https://github.com/Herschel/) and [@Dinnerbone](https://github.com/Dinnerbone/), the desktop app now has a menu bar and context menu! You can also open SWF files by dragging them into the Ruffle window.
 
 <img src="/2023-05-progress-report/RuffleDesktopGUI.png">
 
-### Ruffle now has a built-in save manager!
+## Ruffle now has a built-in save manager!
 Thanks to the work of [@danielhjacobs](https://github.com/danielhjacobs/), web builds of Ruffle allow you to back up and restore your progress for any game. Just right-click => Open Save Manager!
 
 <img src="/2023-05-progress-report/SaveManager.png">
 
-### We're looking for help localizing Ruffle to other languages!
+## We're looking for help localizing Ruffle to other languages!
 If you'd like to help translate Ruffle into your language, please [join our new CrowdIn project](https://crowdin.com/project/ruffle).
 
-### Ruffle finally supports copying and pasting text!
+## Ruffle finally supports copying and pasting text!
 Thanks to the efforts of [myself](https://github.com/n0samu/) and [@Toad06](https://github.com/Toad06/), editable text boxes in Ruffle now support cutting, copying and pasting. You can also press Ctrl-A to select all. Check out the demo below, where I create, copy and paste a level code in *Super Mario Flash*!
 
 <video muted autoplay controls>
     <source src="/2023-05-progress-report/SuperMarioFlashCopyPasteDemo.mp4" type="video/mp4">
 </video>
 
-### We have more awesome things coming up!
+## We have more awesome things coming up!
 - Tonight's Ruffle build will feature some major **desktop interface improvements** from [@Dinnerbone](https://github.com/Dinnerbone/)!
 
     <img src="/2023-05-progress-report/DesktopGUIAdvancedOpen.png" style="max-height: 500px">

--- a/blog_posts/2024-01-14-2023-in-review.markdown
+++ b/blog_posts/2024-01-14-2023-in-review.markdown
@@ -20,7 +20,7 @@ Since the last blog post...
 
 ---
 
-### Display Filters
+## Display Filters
 We've now implemented 7 out of 10 of Flash's filter effects, making content look much more accurate (and lots of text actually legible!)
 
 Along with filter support, we've also implemented `cacheAsBitmap` support - a huge optimisation for games that use it, saving us the need to render the same thing every single frame!
@@ -29,7 +29,7 @@ Along with filter support, we've also implemented `cacheAsBitmap` support - a hu
 
 [The remaining 3 filters](https://github.com/ruffle-rs/ruffle/issues/15) don't seem to be used often, but we welcome anyone who wishes to come help implement them! Support for the existing filters was done by [@Dinnerbone](https://github.com/Dinnerbone) and [@torokati44](https://github.com/torokati44).
 
-### Text improvements
+## Text improvements
 On the topic of rendering, we've been picking and poking at fonts for a while now - and through our combined efforts we're finally starting to see the light at the end of this pixelated and wrongly shaped tunnel.
 
 [@Lord-McSweeney](https://github.com/Lord-McSweeney) has implemented basic Text Layout Framework (TLF) support, which has started to get some more advanced text rendering working.
@@ -45,7 +45,7 @@ With device font support landing, content that didn't embed their own font will 
 <a href="/2024-01-14-2023-in-review/aq.png" target="_blank"><img src="/2024-01-14-2023-in-review/aq.png" title="Adventure Quest, before and after" alt="Adventure Quest, before and after" style="max-height: 300px"></a>
 <a href="/2024-01-14-2023-in-review/spongebob.png" target="_blank"><img src="/2024-01-14-2023-in-review/spongebob.png" title="SpongeBob SquarePants: Plunder Blunder, before and after" alt="SpongeBob SquarePants: Plunder Blunder, before and after device texts" style="max-height: 300px"></a>
 
-### Sockets... even on the web!
+## Sockets... even on the web!
 This has definitely been one of the biggest hurdles to emulating Flash, but the incredible [@sleepycatcoding](https://github.com/sleepycatcoding) came in and made it happen.
 
 Any kind of multiplayer game such as Gaia, Habbo or Club Penguin relied on sockets (TCP sockets, or XML sockets) to function - and nobody was sure if we'd manage to get these working on the web. Modern browsers just don't like that sort of thing!
@@ -57,44 +57,44 @@ On desktop it's now supported out of the box (but will prompt you for permission
     <source src="/2024-01-14-2023-in-review/transformice.mp4" type="video/mp4">
 </video>
 
-### Flash remoting
+## Flash remoting
 In addition to sockets, another common way for online games to work was a protocol called "Flash Remoting", using `NetConnection`.
 This was most notably seen in any game that uses the Armor Games API, and we're happy to say that that now works more or less as expected!
 
-### FLV and video playback
+## FLV and video playback
 This has been a tricky one, but [@kmeisthax](https://github.com/kmeisthax) has been tackling this all year and making amazing progress. Ruffle now supports FLV playback, depending on which codec is required, and [@danielhjacobs](https://github.com/danielhjacobs) has added a workaround for patented codecs on the web by playing them using the browser over the top of the content (or on desktop, just opening the browser).
 
 There's still a lot of progress to be made here, and [@torokati44](https://github.com/torokati44) has a working prototype of decoding H.264 using Cisco's OpenH264 which is very exciting!
 
-### Initial AIR support
+## Initial AIR support
 This was a long time stretch goal that's starting to see reality thanks to [@Aaron1011](https://github.com/Aaron1011)! We now properly version the ActionScript 3 API, and this has been extended to allow AIR-only classes and methods.
 
 We don't have much to show for AIR stuff yet, but the framework to get us here has already helped close off many longstanding compatibility bugs when movies don't expect certain methods or properties to exist for the version of Flash they target.
 
-### Mixed AVM
+## Mixed AVM
 On the topic of longstanding bugs, [@Lord-McSweeney](https://github.com/Lord-McSweeney) has been working on allowing mixed-avm movies to run correctly - these are usually ActionScript 3 games running inside ActionScript 2 containers, or vice versa.
 
 There's still more to do here, but it's already helped unblock lots of content from just mysteriously failing to start!
 
-### Extension improvements
+## Extension improvements
 The extension now uses Manifest V3 (somewhat reluctantly), which enables us to... keep existing. Unfortunately this came with needing to remove the "go to a swf url and play it in the browser" feature, as that's no longer possible with MV3.
 
 However, the upside to this is that we're now [in the Edge store](https://microsoftedge.microsoft.com/addons/detail/ruffle/pipjjbgofgieknlpefmcckdmgaaegban)! Also, thanks to work from [@kmeisthax](https://github.com/kmeisthax) and [@danielhjacobs](https://github.com/danielhjacobs), we're also now available on Firefox for Android! [Check it out!](https://addons.mozilla.org/android/addon/ruffle_rs)
 
 [@WumboSpasm](https://github.com/WumboSpasm) also redesigned the demo player in the extension, which [@danielhjacobs](https://github.com/danielhjacobs) made serve as the replacement for the aforementioned swf-url feature. It looks pretty neat!
 
-### Desktop UI
+## Desktop UI
 Whilst we had a super basic UI introduced in our last blog post, now it's even better! It's still as simple to use as before, but the new Advanced Open menu has many new options you can toggle to change how content plays - plus we've added a host of brand new debug tools that even Flash Player didn't have!
 
 <a href="/2024-01-14-2023-in-review/ui-open-advanced.png" target="_blank"><img src="/2024-01-14-2023-in-review/ui-open-advanced.png" title="Ruffle's Open Advanced menu" alt="Ruffle's Open Advanced menu" style="max-height: 300px"></a>
 <a href="/2024-01-14-2023-in-review/ui-debug.png" target="_blank"><img src="/2024-01-14-2023-in-review/ui-debug.png" title="Ruffle's debug tools" alt="Ruffle's debug tools" style="max-height: 300px"></a>
 
-### New website
-Whilst not Ruffle itself, the website got some much-needed love from [@Dinnerbone](https://github.com/Dinnerbone) with a total redesign. There's a lot more we'd like to do in the future with it, but web development isn't the specialty of any of our regular contributors... help is very much welcome! 
+## New website
+Whilst not Ruffle itself, the website got some much-needed love from [@Dinnerbone](https://github.com/Dinnerbone) with a total redesign. There's a lot more we'd like to do in the future with it, but web development isn't the specialty of any of our regular contributors... help is very much welcome!
 
 We've also pulled in all the improvements to the Extension's demo player, and brought those over to the website too.
 
-### Too many contributions to call out!
+## Too many contributions to call out!
 There's been just so many PRs landing that not everything can take the spotlight here. We'd like to thank every single person who helped shape Ruffle in 2023, and hope that 2024 brings more great progress.
 
 In addition, a big thank you to our sponsors who help keep the project alive. We appreciate you all!


### PR DESCRIPTION
Headings should start at h2 in posts, not h1, because h1 is the title, and not h3, because it's semantically weird and too small.