### PR TITLE
Omit referer in suggested script tag

### DIFF
--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -30,7 +30,7 @@ function WebDownload({ latest }: { latest: GithubRelease | null }) {
         the latest available version of Ruffle.
       </Text>
       <Code block className={classes.cdn}>
-        {'<script src="https://unpkg.com/@ruffle-rs/ruffle"></script>'}
+        {'<script src="https://unpkg.com/@ruffle-rs/ruffle" referrerpolicy="no-referrer"></script>'}
       </Code>
       <Text>
         If you'd like to host it yourself, you can grab{" "}


### PR DESCRIPTION
Avoids leaking to unpkg the domain of the site that's embedding Ruffle.