### PR TITLE
Mark some "hero"-like images as `priority`

### DIFF
--- a/src/app/compatibility/avm2/page.tsx
+++ b/src/app/compatibility/avm2/page.tsx
@@ -44,6 +44,7 @@ export default async function Page() {
             alt="Person viewing ActionScript classes"
             width={208}
             height={200}
+            priority
             className={classes.progressImage}
           />
           <Stack className={classes.actionscriptInfo}>

--- a/src/app/compatibility/page.tsx
+++ b/src/app/compatibility/page.tsx
@@ -43,6 +43,7 @@ export default async function Downloads() {
             alt="Person comparing Ruffle compatibility"
             width={219}
             height={200}
+            priority
             className={classes.actionscriptImage}
           />
           <Stack className={classes.actionscriptInfo}>

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -157,6 +157,7 @@ export default function Page() {
           alt="Person thanking you"
           width={185}
           height={200}
+          priority
           className={classes.image}
         />
         <Stack className={classes.actionscriptInfo}>

--- a/src/app/downloads/extensions.tsx
+++ b/src/app/downloads/extensions.tsx
@@ -36,6 +36,7 @@ function ExtensionBadge(info: Extension) {
         alt={info.alt}
         width={0} // set by css to 100% width
         height={66}
+        priority
         className={classes.badge}
       />
     </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,6 +41,7 @@ export default async function Home() {
             alt="Person installing Ruffle"
             width={375}
             height={366}
+            priority
           />
           <div className={classes.heroInner}>
             <Text mt="md">


### PR DESCRIPTION
To disable lazy-loading for them, which I found annoying.