### PR TITLE
Bump AVM1 language to 99%

### DIFF
--- a/src/app/compatibility/page.tsx
+++ b/src/app/compatibility/page.tsx
@@ -82,7 +82,7 @@ export default async function Downloads() {
         >
           <AvmBlock
             name="AVM 1: ActionScript 1 & 2"
-            language={{ done: 95 }}
+            language={{ done: 99 }}
             api={{ done: avm1ApiDone }}
             info_link_target="_blank"
             info_link="https://github.com/ruffle-rs/ruffle/issues/310"


### PR DESCRIPTION
We've talked about this for ages, it's time to finally do it.

Reasons:

- It hasn't been updated since https://github.com/ruffle-rs/ruffle/pull/16284
- We've just closed a long-standing issue in https://github.com/ruffle-rs/ruffle/issues/701
- While it wasn't a proper fix, a panic source was just resolved in https://github.com/ruffle-rs/ruffle/pull/19594

So why not 100%:

- The last PR mentioned did not fix the fact that the depth and render list can become desynced
- There are still some known language bugs, such as https://github.com/ruffle-rs/ruffle/issues/14562
- Not sure if it's language, but there are still known Electric Man 2 issues
- Not sure if it's language, but there is still my old issue https://github.com/ruffle-rs/ruffle/issues/6254