### PR TITLE
build(deps): bump @mantine/[hooks,charts,core] from 7.17.5 to 8.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "ruffle-website",
       "version": "0.1.0",
       "dependencies": {
-        "@mantine/charts": "^7.17.5",
-        "@mantine/core": "7.17.5",
-        "@mantine/hooks": "7.17.5",
+        "@mantine/charts": "^8.0.0",
+        "@mantine/core": "^8.0.0",
+        "@mantine/hooks": "^8.0.0",
         "@next/bundle-analyzer": "15.3.1",
         "@tabler/icons-react": "^3.31.0",
         "next": "15.3.1",
@@ -351,21 +351,21 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.0.tgz",
+      "integrity": "sha512-FRdBLykrPPA6P76GGGqlex/e7fbe0F1ykgxHYNXQsH/iTEtjMj/f9bpY5oQqbjt5VgZvgz/uKXbGuROijh3VLA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.0.tgz",
+      "integrity": "sha512-lGTor4VlXcesUMh1cupTUTDoCxMb0V6bm3CnxHzQcw8Eaf1jQbgQX4i02fYgT0vJ82tb5MZ4CZk1LRGkktJCzg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/core": "^1.7.0",
         "@floating-ui/utils": "^0.2.9"
       }
     },
@@ -844,22 +844,22 @@
       }
     },
     "node_modules/@mantine/charts": {
-      "version": "7.17.5",
-      "resolved": "https://registry.npmjs.org/@mantine/charts/-/charts-7.17.5.tgz",
-      "integrity": "sha512-VDDRwUqTsZYqYSYqcc8wXrdiKIvkqRcoDQXKdiuSin7ebQtk29QnPDQmcM536HQpVlUuemI7iTJNTUmhdc7ALQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@mantine/charts/-/charts-8.0.0.tgz",
+      "integrity": "sha512-VlkcRmDiPcn09CX5lu/L8RutywSxFH0Tzk3FkkYmfm6LurSI+xoyF86GjMa6JesjFsUCO3+qMaq5IvM4joThjg==",
       "license": "MIT",
       "peerDependencies": {
-        "@mantine/core": "7.17.5",
-        "@mantine/hooks": "7.17.5",
+        "@mantine/core": "8.0.0",
+        "@mantine/hooks": "8.0.0",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x",
         "recharts": "^2.13.3"
       }
     },
     "node_modules/@mantine/core": {
-      "version": "7.17.5",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-7.17.5.tgz",
-      "integrity": "sha512-66g/lr281cDPfucjtPw8gFo/yNS9G5iSKqysvPGuDpUBG2bEw8FsJMIsU0bMXtravToIpa3vJRrFUuPndPGnpQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.0.0.tgz",
+      "integrity": "sha512-TskeJS2/+DbmUe85fXDoUAyErkSvR4YlbUl8MLqhjFBJUqwc72ZrLynmN13wuKtlVPakDYYjq4/IEDMReh3CYA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.26.28",
@@ -870,15 +870,15 @@
         "type-fest": "^4.27.0"
       },
       "peerDependencies": {
-        "@mantine/hooks": "7.17.5",
+        "@mantine/hooks": "8.0.0",
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/hooks": {
-      "version": "7.17.5",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-7.17.5.tgz",
-      "integrity": "sha512-Q/3AHI1fjl+W7xQ3jEoMmSoTxLqxMI2gPfxIjd73OPmRpPenYWR1zk/diirXXm2t7JOrAbmpA3/O1gzmgqzc/Q==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.0.0.tgz",
+      "integrity": "sha512-hrcgZMHUPsgu+VBfUVcJOqMG7Qi+AshYjFyc/qo0Cz8TEhqWmD0I1yJW+qj4sDTTDWRQC6kvI5c1h+87/9MvoA==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
@@ -8055,9 +8055,9 @@
       }
     },
     "node_modules/react-number-format": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.3.tgz",
-      "integrity": "sha512-VCY5hFg/soBighAoGcdE+GagkJq0230qN6jcS5sp8wQX1qy1fYN/RX7/BXkrs0oyzzwqR8/+eSUrqXbGeywdUQ==",
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/react-number-format/-/react-number-format-5.4.4.tgz",
+      "integrity": "sha512-wOmoNZoOpvMminhifQYiYSTCLUDOiUbBunrMrMjA+dV52sY+vck1S4UhR6PkgnoCquvvMSeJjErXZ4qSaWCliA==",
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9386,9 +9386,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "4.38.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
-      "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.1.tgz",
+      "integrity": "sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=16"

--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@mantine/charts": "^7.17.5",
-    "@mantine/core": "7.17.5",
-    "@mantine/hooks": "7.17.5",
+    "@mantine/charts": "^8.0.0",
+    "@mantine/core": "^8.0.0",
+    "@mantine/hooks": "^8.0.0",
     "@next/bundle-analyzer": "15.3.1",
     "@tabler/icons-react": "^3.31.0",
     "next": "15.3.1",


### PR DESCRIPTION
This is basically these three (interdependent) PRs in one (they should be grouped for Dependabot I guess):

 - https://github.com/ruffle-rs/ruffle-rs.github.io/pull/407
 - https://github.com/ruffle-rs/ruffle-rs.github.io/pull/409
 - https://github.com/ruffle-rs/ruffle-rs.github.io/pull/410