### PR TITLE
Add stable releases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@types/node": "^25",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/semver": "^7.7.1",
         "@typescript-eslint/eslint-plugin": "^8.58.2",
         "@typescript-eslint/parser": "^8.58.2",
         "d3": "^7.9.0",
@@ -46,6 +47,7 @@
         "react-markdown": "^10.1.0",
         "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
+        "semver": "^7.8.0",
         "typescript": "^6.0.3"
       }
     },
@@ -2523,6 +2525,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -8930,9 +8939,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^25",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/semver": "^7.7.1",
     "@typescript-eslint/eslint-plugin": "^8.58.2",
     "@typescript-eslint/parser": "^8.58.2",
     "d3": "^7.9.0",
@@ -48,6 +49,7 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
+    "semver": "^7.8.0",
     "typescript": "^6.0.3"
   }
 }

--- a/src/app/downloads/config.tsx
+++ b/src/app/downloads/config.tsx
@@ -14,9 +14,12 @@ import { SummaryStatistics } from "@/app/compatibility/avm2/report_utils";
 
 export const repository = { owner: "ruffle-rs", repo: "ruffle" };
 
+export const maxMinor = 3;
+export const maxMajor = 1;
 export const maxNightlies = 5;
 
 export const githubReleasesUrl = `https://github.com/${repository.owner}/${repository.repo}/releases`;
+export const githubStableReleasesUrl = `${githubReleasesUrl}?q=prerelease:false`;
 export const githubNightlyReleasesUrl = `${githubReleasesUrl}?q=prerelease:true`;
 
 export const flathubUrl = "https://flathub.org/apps/rs.ruffle.Ruffle";

--- a/src/app/downloads/github.tsx
+++ b/src/app/downloads/github.tsx
@@ -5,6 +5,8 @@ import {
   DownloadKey,
   FilenamePatterns,
   GithubRelease,
+  maxMajor,
+  maxMinor,
   maxNightlies,
   ReleaseDownloads,
   repository,
@@ -12,6 +14,7 @@ import {
 import { Octokit } from "octokit";
 import { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
 import { parse } from "node-html-parser";
+import semver from "semver/preload";
 import { components } from "@octokit/openapi-types";
 
 const octokit = new Octokit({ authStrategy: createGithubAuth });
@@ -61,17 +64,44 @@ function mapRelease(release: components["schemas"]["release"]): GithubRelease {
   };
 }
 
-export async function getLatestReleases(): Promise<GithubRelease[]> {
+export async function getLatestRelease(): Promise<GithubRelease> {
+  try {
+    const response = await octokit.rest.repos.getLatestRelease({
+      ...requestCache,
+      ...repository,
+    });
+    return mapRelease(response.data);
+  } catch {
+    // There's no latest release, get the last one.
+  }
+
+  const releases = await octokit.rest.repos.listReleases({
+    per_page: 1,
+    ...requestCache,
+    ...repository,
+  });
+  return mapRelease(releases.data[0]);
+}
+
+export async function getLatestNightlyReleases(): Promise<GithubRelease[]> {
   try {
     const releases = await octokit.rest.repos.listReleases({
-      // Assume there's less regular releases than nightlies.
+      // Assume there's fewer regular releases than nightlies.
       per_page: maxNightlies * 2,
       ...requestCache,
       ...repository,
     });
     const result = [];
     for (const release of releases.data) {
+      if (!release.prerelease) {
+        // Filter out stable releases
+        continue;
+      }
       result.push(mapRelease(release));
+
+      if (result.length >= maxNightlies) {
+        break;
+      }
     }
     return result;
   } catch (error) {
@@ -80,14 +110,89 @@ export async function getLatestReleases(): Promise<GithubRelease[]> {
   }
 }
 
+export async function getLatestStableReleases(): Promise<GithubRelease[]> {
+  let newestMajor = null;
+
+  // Map representing releases from the current major version:
+  //   `major.minor` -> `major.minor.patch`
+  // We want to ignore older patches and show last X minor versions.
+  const currentMajorReleases = new Map();
+
+  // Map representing releases from older major versions.
+  //   `major` -> `major.minor.patch`
+  // We ignore here minor and patch versions, and
+  // gather the newest release per each major.
+  const olderMajors = new Map();
+
+  for (
+    let page = 1;
+    currentMajorReleases.size < maxMinor || olderMajors.size < maxMajor - 1;
+    ++page
+  ) {
+    console.log(`Fetching releases page ${page}`);
+
+    const request = await octokit.rest.repos.listReleases({
+      // 100 per page disables cache as the result is >2MB
+      per_page: 50,
+      page: page,
+      ...requestCache,
+      ...repository,
+    });
+
+    if (request.status != 200 || request.data.length == 0) {
+      break;
+    }
+
+    let shouldFinish = false;
+    for (const data of request.data) {
+      if (data.prerelease) {
+        continue;
+      }
+
+      const release = mapRelease(data);
+
+      const version = release.tag.replace(/^v/, "");
+      const major = semver.major(version);
+      const majorMinor = `${major}.${semver.minor(version)}`;
+
+      if (!newestMajor) {
+        newestMajor = major;
+      }
+
+      if (major === newestMajor) {
+        if (!currentMajorReleases.has(majorMinor)) {
+          currentMajorReleases.set(majorMinor, release);
+        }
+      } else {
+        if (!olderMajors.has(major)) {
+          olderMajors.set(major, release);
+        }
+      }
+
+      if (data.tag_name === "v0.2.0") {
+        // 0.2.0 was our first stable release, stop the search here.
+        shouldFinish = true;
+        break;
+      }
+    }
+
+    if (shouldFinish) {
+      break;
+    }
+  }
+
+  return Array.from(currentMajorReleases.values())
+    .slice(0, maxMinor)
+    .concat(Array.from(olderMajors.values()).slice(0, maxMajor - 1));
+}
+
 export async function getWeeklyContributions(): Promise<
   RestEndpointMethodTypes["repos"]["getCommitActivityStats"]["response"]
 > {
-  const octokit = new Octokit({ authStrategy: createGithubAuth });
   return octokit.rest.repos.getCommitActivityStats(repository);
 }
 export async function fetchReport(): Promise<AVM2Report | undefined> {
-  const releases = await getLatestReleases();
+  const releases = await getLatestNightlyReleases();
   const latest = releases.find(
     (release) => release.avm2_report_asset_id !== undefined,
   );
@@ -95,10 +200,8 @@ export async function fetchReport(): Promise<AVM2Report | undefined> {
     throwBuildError();
     return;
   }
-  const octokit = new Octokit({ authStrategy: createGithubAuth });
   const asset = await octokit.rest.repos.getReleaseAsset({
-    owner: repository.owner,
-    repo: repository.repo,
+    ...repository,
     asset_id: latest.avm2_report_asset_id,
     headers: {
       accept: "application/octet-stream",
@@ -113,10 +216,8 @@ export async function fetchReport(): Promise<AVM2Report | undefined> {
 }
 
 export async function getAVM1Progress(): Promise<number> {
-  const octokit = new Octokit({ authStrategy: createGithubAuth });
   const issues = await octokit.rest.issues.listForRepo({
-    owner: repository.owner,
-    repo: repository.repo,
+    ...repository,
     labels: "avm1-tracking",
     state: "all",
     per_page: 65,

--- a/src/app/downloads/page.tsx
+++ b/src/app/downloads/page.tsx
@@ -16,9 +16,12 @@ import {
   desktopLinks,
   GithubRelease,
   githubReleasesUrl,
-  maxNightlies,
 } from "@/app/downloads/config";
-import { getLatestReleases } from "@/app/downloads/github";
+import {
+  getLatestNightlyReleases,
+  getLatestRelease,
+  getLatestStableReleases,
+} from "@/app/downloads/github";
 
 function WebDownload({ latest }: { latest: GithubRelease | null }) {
   return (
@@ -94,18 +97,17 @@ function DesktopDownload({ latest }: { latest: GithubRelease | null }) {
 }
 
 export default async function Page() {
-  const releases = await getLatestReleases();
-  const latest = releases.length > 0 ? releases[0] : null;
-  const nightlies = releases
-    .filter((release) => release.prerelease)
-    .slice(0, maxNightlies);
+  const stableReleases = await getLatestStableReleases();
+  const nightlies = await getLatestNightlyReleases();
+  const latestStable = await getLatestRelease();
   return (
     <Container size="xl" className={classes.container}>
       <Stack gap="xl">
         <ExtensionList />
-        <WebDownload latest={latest} />
-        <DesktopDownload latest={latest} />
+        <WebDownload latest={latestStable} />
+        <DesktopDownload latest={latestStable} />
 
+        <ReleaseList releases={stableReleases} nightly={false} />
         <ReleaseList releases={nightlies} nightly={true} />
       </Stack>
     </Container>

--- a/src/app/downloads/releases.tsx
+++ b/src/app/downloads/releases.tsx
@@ -20,8 +20,9 @@ import {
   desktopLinks,
   type DownloadLink,
   extensionLinks,
-  type GithubRelease,
   githubNightlyReleasesUrl,
+  githubStableReleasesUrl,
+  type GithubRelease,
   webLinks,
 } from "@/app/downloads/config";
 
@@ -55,8 +56,8 @@ function DownloadLink({
 }
 
 function ReleaseRow(release: GithubRelease) {
-  // The nightly prefix is a bit superfluous here
-  const name = release.name.replace(/^Nightly /, "");
+  // The prefix is a bit superfluous here
+  const name = release.name.replace(/^Nightly /, "").replace(/^Release /, "");
   return (
     <TableTr>
       <TableTd>
@@ -119,27 +120,38 @@ function ReleaseCompactBox(release: GithubRelease) {
 
 function ReleaseIntro({ nightly }: { nightly: boolean }) {
   if (!nightly) {
-    throw new Error("Only nightly releases supported");
+    return (
+      <>
+        <Title id="releases">Releases</Title>
+        <Text>
+          If none of the above are suitable for you, you can manually download
+          one of the latest releases. Older versions are available on{" "}
+          <Link href={githubStableReleasesUrl} target="_blank">
+            GitHub
+          </Link>
+          .
+        </Text>
+      </>
+    );
+  } else {
+    return (
+      <>
+        <Title id="nightly-releases">Nightly Releases</Title>
+        <Text>
+          If you want to try out the latest updates and cutting-edge features,
+          you can download the latest nightly release. These are automatically
+          built every day (approximately midnight UTC, unless there are no
+          changes on that day) and they offer early access to new enhancements,
+          bug fixes, and improvements before they're officially rolled out.
+          Older nightly releases are available on{" "}
+          <Link href={githubNightlyReleasesUrl} target="_blank">
+            GitHub
+          </Link>
+          .
+        </Text>
+      </>
+    );
   }
-  return (
-    <>
-      <Title id="nightly-releases">Nightly Releases</Title>
-      <Text>
-        If none of the above are suitable for you, you can manually download the
-        latest Nightly release. These are automatically built every day
-        (approximately midnight UTC), unless there are no changes on that day.{" "}
-        Older nightly releases are available on{" "}
-        <Link
-          href={githubNightlyReleasesUrl}
-          className={classes.moreNightlies}
-          target="_blank"
-        >
-          GitHub
-        </Link>
-        .
-      </Text>
-    </>
-  );
 }
 
 export function ReleaseList({
@@ -149,6 +161,10 @@ export function ReleaseList({
   releases: GithubRelease[];
   nightly: boolean;
 }) {
+  if (releases.length == 0) {
+    return <></>;
+  }
+
   return (
     <Stack>
       <ReleaseIntro nightly={nightly} />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ import {
 import Image from "next/image";
 import { IconCheck } from "@tabler/icons-react";
 import React from "react";
-import { getLatestReleases } from "@/app/downloads/github";
+import { getLatestRelease } from "@/app/downloads/github";
 import { GithubRelease } from "./downloads/config";
 
 const InteractiveLogo = dynamic(() => import("../components/logo"), {
@@ -31,8 +31,7 @@ export default function Home() {
   React.useEffect(() => {
     const fetchReleases = async () => {
       try {
-        const releases = await getLatestReleases();
-        setLatest(releases.length > 0 ? releases[0] : null);
+        setLatest(await getLatestRelease());
       } catch (err) {
         console.warn("Failed to fetch releases", err);
       }


### PR DESCRIPTION
Updated version of https://github.com/ruffle-rs/ruffle-rs.github.io/pull/308.

The main page will show download options based on the latest release, and there's a new section with releases on the downloads page.

<img height="1000" alt="image" src="https://github.com/user-attachments/assets/b6105f7e-48f8-41f7-a37f-31c26bfff519" />
